### PR TITLE
devices/juno-r2: fix kernel image type

### DIFF
--- a/devices/juno-r2
+++ b/devices/juno-r2
@@ -24,6 +24,10 @@ context:
     commands: nfs
 {% endblock boot_commands %}
 
+{% block kernel_extra_args %}
+      type: image
+{% endblock kernel_extra_args %}
+
 {% block test_target %}
   {{ super() }}
     - from: inline


### PR DESCRIPTION
Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>