### PR TITLE
devices: move disk mounting section to separate 'test'

### DIFF
--- a/devices/juno-r2
+++ b/devices/juno-r2
@@ -29,7 +29,11 @@ context:
 {% endblock kernel_extra_args %}
 
 {% block test_target %}
-  {{ super() }}
+- test:
+    namespace: target
+    timeout:
+      minutes: 5
+    definitions:
     - from: inline
       repository:
         metadata:
@@ -47,4 +51,5 @@ context:
           - mount
       name: prep-inline
       path: inline/prep.yaml
+  {{ super() }}
 {% endblock test_target %}

--- a/devices/x86
+++ b/devices/x86
@@ -28,7 +28,11 @@ context:
 {% endblock auto_login_commands %}
 
 {% block test_target %}
-  {{ super() }}
+- test:
+    namespace: target
+    timeout:
+      minutes: 5
+    definitions:
     - from: inline
       repository:
         metadata:
@@ -46,5 +50,6 @@ context:
           - mount
       name: prep-tmp-disk
       path: inline/prep.yaml
+  {{ super() }}
 {% endblock test_target %}
 


### PR DESCRIPTION
Some device+test combinations are causing issues with YAML rendering.
Separating disk mounting section into separate test block solves this
problem for juno and x86

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>