### PR TITLE
lkft: lava: devices: juno: remove namespace recovery

### DIFF
--- a/devices/juno-r2
+++ b/devices/juno-r2
@@ -17,7 +17,6 @@ context:
 
 {% block boot_target %}
 {{ super() }}
-    connection-namespace: recovery
 {% endblock boot_target %}
 
 {% block boot_commands %}


### PR DESCRIPTION
LAVA complains about the recovery namespace like this:

Job error: Unable to reuse connection from namespace 'recovery'

Rework not to use it.

Reported-by: Daniel Díaz <daniel.diaz@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>