### PR TITLE
dry-run: fix file paths passed to LAVA container

### DIFF
--- a/submit_for_testing.py
+++ b/submit_for_testing.py
@@ -380,14 +380,13 @@ def main():
         client = docker.from_env()
         logger.debug("Checking for LAVA validity")
         for test in test_list:
-            testpath = os.path.join(
-                os.getcwd(), output_path, args.device_type, os.path.basename(test)
-            )
+            testpath = os.path.join(os.getcwd(), output_path, args.device_type)
             logger.debug(testpath)
             logger.debug(test)
             container = client.containers.run(
                 image="lavasoftware/amd64-lava-server:2019.07",
-                command="/usr/share/lava-common/lava-schema.py job /data/%s" % test,
+                command="/usr/share/lava-common/lava-schema.py job /data/%s"
+                % test.rsplit("/", maxsplit=1)[1],
                 volumes={"%s" % testpath: {"bind": "/data", "mode": "rw"}},
                 detach=True,
             )


### PR DESCRIPTION
Checking generated jobs with LAVA container was not working properly.
Paths and file names passed to container were incorrect and LAVA schema
checker ignored it. This patch fixes the file paths and makes LAVA
schema validator work again.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>