### PR TITLE
devices: fix boot to bootloader in rzn1d and soca9

### DIFF
--- a/devices/rzn1d
+++ b/devices/rzn1d
@@ -2,9 +2,9 @@
 
 {% set run_nand_commands = true %}
 {% set target_deploy_timeout = 5 %}
-{% set boot_method = "u-boot" %}
+{% set boot_method = boot_method|default("u-boot") %}
 {% set target_boot_timeout = 10 %}
-{% set auto_login = true %}
+{% set auto_login = auto_login|default(true) %}
 {% set auto_login_prompt = "login:" %}
 {% set auto_login_username = "root" %}
 {% set auto_login_password_prompt = "Password:" %}
@@ -18,6 +18,7 @@
 {% endblock kernel_extra_args %}
 
 {% block boot_commands %}
+{% if boot_method == "u-boot" %}
     commands:
       - setenv autoload no
       - dhcp
@@ -26,5 +27,9 @@
       - setenv serverip {SERVER_IP}
       - tftp {KERNEL_ADDR} {KERNEL}
       - run LINUX_BOOTARGS
-      - bootm {KERNEL_ADDR}#conf@1 
+      - bootm {KERNEL_ADDR}#conf@1
+{% elif boot_method == "bootloader" %}
+    bootloader: u-boot
+    commands: []
+{% endif %}
 {% endblock boot_commands %}

--- a/devices/soca9
+++ b/devices/soca9
@@ -3,8 +3,8 @@
 {% set run_fpga_command = false %}
 {% set target_deploy_timeout = 5 %}
 {% set rootfs_label = "nfsrootfs" %}
-{% set boot_method = "u-boot" %}
-{% set auto_login = true %}
+{% set boot_method = boot_method|default("u-boot") %}
+{% set auto_login = auto_login|default(true) %}
 {% set auto_login_prompt = "login:" %}
 {% set auto_login_username = "root" %}
 {% set auto_login_password_prompt = "Password:" %}
@@ -31,6 +31,7 @@
 {% endblock kernel_extra_args %}
 
 {% block boot_commands %}
+{% if boot_method == "u-boot" %}
     commands:
       - run FPGA_INIT
       - setenv autoload no
@@ -42,6 +43,10 @@
       - tftp 0x00000100 {DTB}
       - "setenv bootargs 'console=ttyS0,115200n8 root=/dev/nfs rw nfsroot={NFS_SERVER_IP}:{NFSROOTFS},tcp,hard,intr,vers=3 rootwait coherent_pool=2M ip=dhcp'"
       - '{BOOTX}'
+{% elif boot_method == "bootloader" %}
+    bootloader: u-boot
+    commands: []
+{% endif %}
 {% endblock boot_commands %}
 
 {% block auto_login_commands %}


### PR DESCRIPTION
When booting to bootloader u-boot commands and login prompts should not
be included in the boot action.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>