### PR TITLE
master: fix indentation of job context

### DIFF
--- a/devices/juno-r2
+++ b/devices/juno-r2
@@ -6,12 +6,11 @@
 {% set auto_login_prompt = "login:" %}
 {% set auto_login_username = "root" %}
 {% set boot_method = "u-boot" %}
+{% set use_context = true %}
 
-{% block global_settings %}
-{{ super() }}
-context:
+{% block context %}
   bootloader_prompt: juno#
-{% endblock global_settings %}
+{% endblock context %}
 
 {% block device_type %}juno-r2{% endblock %}
 

--- a/devices/nxp-ls2088
+++ b/devices/nxp-ls2088
@@ -6,12 +6,11 @@
 {% set auto_login_prompt = "login:" %}
 {% set auto_login_username = "root" %}
 {% set boot_method = "u-boot" %}
+{% set use_context = true %}
 
-{% block global_settings %}
-{{ super() }}
-context:
+{% block context %}
   arch: arm64
-{% endblock global_settings %}
+{% endblock context %}
 
 {% block device_type %}nxp-ls2088{% endblock %}
 

--- a/devices/x86
+++ b/devices/x86
@@ -7,12 +7,11 @@
 {% set auto_login_username = "root" %}
 {% set boot_method = "ipxe" %}
 {% set BOOT_OS_PROMPT = "root@intel-corei7-64:" %}
+{% set use_context = true %}
 
-{% block global_settings %}
-{{ super() }}
-context:
+{% block context %}
   test_character_delay: 10
-{% endblock global_settings %}
+{% endblock context %}
 
 {% block device_type %}x86{% endblock %}
 

--- a/lkft-fastboot.jinja2
+++ b/lkft-fastboot.jinja2
@@ -1,5 +1,7 @@
 {% extends "lkft.jinja2" %}
 
+{% set use_context = true %}
+
 {% if install_packages is undefined %}{% set install_packages = true %}{% endif %}
 {% if install_fastboot is undefined %}{% set install_fastboot = true %}{% endif %}
 {% if ptable is undefined %}{% set prable = false %}{% endif %}
@@ -16,11 +18,9 @@
 
 
 
-{% block global_settings %}
-{{ super() }}
-context:
+{% block context %}
   test_character_delay: 10
-{% endblock global_settings %}
+{% endblock context %}
 
 {% block protocols %}
 protocols:

--- a/lkft.jinja2
+++ b/lkft.jinja2
@@ -20,6 +20,12 @@ timeouts:
   connection:
     minutes: 2
 
+{% if use_context is defined and use_context == true %}
+context:
+{% block context %}
+{% endblock context %}
+{% endif %}
+
 {% block settings %}
 {% endblock settings %}
 {% endblock global_settings %}

--- a/testcases/master/template-kselftest.yaml.jinja2
+++ b/testcases/master/template-kselftest.yaml.jinja2
@@ -5,17 +5,18 @@
   {%- set vsyscall_suffix = "-vsyscall-mode-"+vsyscall_mode %}
 {%- endif -%}
 {% set test_name = "kselftests" + vsyscall_suffix %}
+{% set use_context = true %}
 
 {% extends "testcases/master/template-master.jinja2" %}
 
-{% block global_settings %}
+{% block context %}
 {{ super() }}
   {#- If vsyscall_mode is defined, pass it as an extra kernel argument #}
   {#- vsyscall_mode may be emulate (default), native, or none.         #}
   {%- if vsyscall_mode is defined %}
   extra_kernel_args: 'vsyscall={{vsyscall_mode}}'
   {%- endif %}
-{% endblock global_settings %}
+{% endblock context %}
 
 {% set test_timeout = 55 %}
 {% block metadata %}

--- a/testcases/master/template-kvm-unit-tests.yaml.jinja2
+++ b/testcases/master/template-kvm-unit-tests.yaml.jinja2
@@ -1,9 +1,11 @@
 {% extends "testcases/master/template-master.jinja2" %}
 
-{% block global_settings %}
+{% set use_context = true %}
+
+{% block context %}
 {{ super() }}
   extra_kernel_args: 'kvm.enable_vmware_backdoor=1 kvm.force_emulation_prefix=1'
-{% endblock global_settings %}
+{% endblock context %}
 
 {% set test_timeout = 25 %}
 {% block metadata %}


### PR DESCRIPTION
Job 'context' was omited in some cases and context variables landed in
'timeouts' section. This patch adds new block where all context
variables should be defined. Also use_context variable should be set to
true in order to activate the block.

Reported-by: Michal Simek <monstr@monstr.eu>
Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>