### PR TITLE
fastboot: Fix packages for Android img tools

### DIFF
--- a/fastboot.jinja2
+++ b/fastboot.jinja2
@@ -45,17 +45,16 @@ protocols:
     - unzip
 {% if install_packages == true %}
     - abootimg
+    - android-tools-fsutils
     - cpio
     - curl
     - e2fsprogs
     - file
     - git
     - gzip
-    - img2simg
     - libguestfs-tools
     - mkbootimg
     - mktemp
-    - simg2img
     - xz-utils
 {% endif %}
     os: debian


### PR DESCRIPTION
Install `android-tools-fsutils` in order to provide `img2simg` and `simg2img`. The current list of packages is invalid:
```
[...]
E: Unable to locate package img2simg
E: Unable to locate package simg2img
Unable to install using apt-get in lxc container
```