### PR TITLE
fastboot: make it possible to have boot and kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ variables:
  * *LAVA_JOB_PRIORITY*: priority of the LAVA job, used by LAVA scheduler
  * *LAVA_JOB_VISIBILITY*: defaults to *public*. This block can be used to restrict job visibility to user or group.
  * *AUTO_LOGIN_*: default *PROMPT='login:', *USERNAME='root' and *PASSWORD=''.
+ * *BOOT_LABEL: default BOOT_LABEL='boot'.
 
 ## Timeouts
 

--- a/devices/qemu_arm
+++ b/devices/qemu_arm
@@ -4,7 +4,7 @@
 {# libhugetlbfs_word_size variable is required for libhugetlbfs.yaml test template #}
 {% set libhuggetlbfs_word_size = 32 %}
 {% set apply_overlay = "rootfs" %}
-{% set boot_label = "kernel" %}
+{% set BOOT_LABEL = "kernel" %}
 {% set rootfs_label = "rootfs" %}
 {% set deploy_target = "tmpfs" %}
 

--- a/devices/qemu_arm64
+++ b/devices/qemu_arm64
@@ -2,7 +2,7 @@
 {% extends PROJECT+"fastboot.jinja2" %}
 
 {% set apply_overlay = "rootfs" %}
-{% set boot_label = "kernel" %}
+{% set BOOT_LABEL = "kernel" %}
 {% set rootfs_label = "rootfs" %}
 {% set boot_image_arg = "-kernel {kernel} --append \"console=ttyAMA0 root=/dev/vda rw\"" %}
 {% set deploy_target = "tmpfs" %}

--- a/devices/qemu_i386
+++ b/devices/qemu_i386
@@ -5,7 +5,7 @@
 {% set libhuggetlbfs_word_size = 32 %}
 {% set rootfs_label = "rootfs" %}
 {% set deploy_target = "tmpfs" %}
-{% set boot_label = "kernel" %}
+{% set BOOT_LABEL = "kernel" %}
 {% set apply_overlay = None %}
 
 {% block global_settings %}

--- a/devices/qemu_x86_64
+++ b/devices/qemu_x86_64
@@ -3,7 +3,7 @@
 
 {% set rootfs_label = "rootfs" %}
 {% set deploy_target = "tmpfs" %}
-{% set boot_label = "kernel" %}
+{% set BOOT_LABEL = "kernel" %}
 {% set apply_overlay = None %}
 
 {% block global_settings %}

--- a/fastboot.jinja2
+++ b/fastboot.jinja2
@@ -6,7 +6,7 @@
 {% if install_fastboot is undefined %}{% set install_fastboot = true %}{% endif %}
 {% if ptable is undefined %}{% set prable = false %}{% endif %}
 {% if boot is undefined %}{% set boot = true %}{% endif %}
-{% if boot_label is undefined %}{% set boot_label = "boot" %}{% endif %}
+{% if BOOT_LABEL is undefined %}{% set BOOT_LABEL = "boot" %}{% endif %}
 {% if rootfs is undefined %}{% set rootfs = true %}{% endif %}
 {% if rootfs_label is undefined %}{% set rootfs_label = 'rootfs' %}{% endif %}
 {% if apply_overlay is undefined %}{% set apply_overlay = "rootfs" %}{% endif %}
@@ -97,7 +97,7 @@ protocols:
 {% endif %}
 {% endif %}
 {% if boot == true %}
-      {{ boot_label }}:
+      {{ BOOT_LABEL }}:
         url: {{BOOT_URL}}
 {% block kernel_extra_args %}
 {% endblock kernel_extra_args %}
@@ -109,7 +109,7 @@ protocols:
 {% endif %}
 {% block boot_extra_args %}
 {% endblock boot_extra_args %}
-{% if boot_label != "kernel" and KERNEL_URL is defined %}
+{% if BOOT_LABEL != "kernel" and KERNEL_URL is defined %}
       kernel:
         url: {{KERNEL_URL}}
 {% if KERNEL_URL_COMP is defined %}

--- a/fastboot.jinja2
+++ b/fastboot.jinja2
@@ -109,6 +109,13 @@ protocols:
 {% endif %}
 {% block boot_extra_args %}
 {% endblock boot_extra_args %}
+{% if boot_label != "kernel" and KERNEL_URL is defined %}
+      kernel:
+        url: {{KERNEL_URL}}
+{% if KERNEL_URL_COMP is defined %}
+        compression: {{KERNEL_URL_COMP}}
+{% endif %}
+{% endif %}
 {% endif %}
 {% if DTB_URL is defined %}
       dtb:

--- a/variables.ini
+++ b/variables.ini
@@ -55,3 +55,4 @@ AUTO_LOGIN_PROMPT=prompt-value
 AUTO_LOGIN_USERNAME=username-value
 AUTO_LOGIN_PASSWORD=password-value
 PROJECT=lkft-
+BOOT_LABEL=boot-label-value


### PR DESCRIPTION
For hikey the boot.img is used for uefi, the kernel, dtb and modules can
be squashed into a generic rootfs.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>