### PR TITLE
submit_for_testing: Disallow unknown arguments

### DIFF
--- a/submit_for_testing.py
+++ b/submit_for_testing.py
@@ -273,7 +273,7 @@ def main():
         default=logging.INFO,
     )
 
-    args, _ = parser.parse_known_args()
+    args = parser.parse_args()
     logger.setLevel(args.verbose)
     exit_code = 0
 


### PR DESCRIPTION
If an unknown argument is given to submit_for_testing it should bail immediately instead of making the user believe that it cares about their feelings and arguments.