### PR TITLE
testplans: lkft-full: remove kselftests

### DIFF
--- a/testplans/lkft-full/kselftests-native.yaml
+++ b/testplans/lkft-full/kselftests-native.yaml
@@ -1,1 +1,0 @@
-../../testcases/kselftests-native.yaml

--- a/testplans/lkft-full/kselftests-none.yaml
+++ b/testplans/lkft-full/kselftests-none.yaml
@@ -1,1 +1,0 @@
-../../testcases/kselftests-none.yaml

--- a/testplans/lkft-full/kselftests.yaml
+++ b/testplans/lkft-full/kselftests.yaml
@@ -1,1 +1,0 @@
-../../testcases/kselftests.yaml


### PR DESCRIPTION
Remove kselftests since in LKFT 2.0 there's no way to build or run
kselftests.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>