### PR TITLE
testplans: lkft-full: remove ltp-open-posix

### DIFF
--- a/testplans/lkft-full/ltp-open-posix.yaml
+++ b/testplans/lkft-full/ltp-open-posix.yaml
@@ -1,1 +1,0 @@
-../../testcases/ltp-open-posix.yaml


### PR DESCRIPTION
ltp-open-posix takes too long to run, so it should only be runned on
x86, i386, x15 and juno.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>