### PR TITLE
testplans: lkft-full: Add LTP short runs

### DIFF
--- a/testplans/lkft-full/ltp-short-runs.yaml
+++ b/testplans/lkft-full/ltp-short-runs.yaml
@@ -1,0 +1,1 @@
+../../testcases/ltp-short-runs.yaml


### PR DESCRIPTION
This is a compilation of short LTP tests suites, including:
* cap_bounds
* cpuhotplug
* fcntl-locktests
* filecaps
* fs_bind
* fs_perms_simple
* fsx
* nptl
* pty
* securebits
