### PR TITLE
fastboot: move package-list to projects

### DIFF
--- a/devices/qcs404-evb-1k
+++ b/devices/qcs404-evb-1k
@@ -4,7 +4,6 @@
 {% block device_type %}qcs404-evb-1k{% endblock %}
 
 {% set rootfs_label = 'userdata' %}
-{% set install_packages = false %}
 {% set install_fastboot = false %}
 {% set pre_power_command = false %}
 {% set pre_os_command = false %}

--- a/devices/qcs404-evb-4k
+++ b/devices/qcs404-evb-4k
@@ -4,7 +4,6 @@
 {% block device_type %}qcs404-evb-4k{% endblock %}
 
 {% set rootfs_label = 'userdata' %}
-{% set install_packages = false %}
 {% set install_fastboot = false %}
 {% set pre_power_command = false %}
 {% set pre_os_command = false %}

--- a/devices/sdm845-mtp
+++ b/devices/sdm845-mtp
@@ -4,7 +4,6 @@
 {% block device_type %}sdm845-mtp{% endblock %}
 
 {% set rootfs_label = 'userdata' %}
-{% set install_packages = false %}
 {% set install_fastboot = false %}
 {% set pre_power_command = false %}
 {% set pre_os_command = false %}

--- a/fastboot.jinja2
+++ b/fastboot.jinja2
@@ -2,7 +2,6 @@
 
 {% set use_context = true %}
 
-{% if install_packages is undefined %}{% set install_packages = true %}{% endif %}
 {% if install_fastboot is undefined %}{% set install_fastboot = true %}{% endif %}
 {% if ptable is undefined %}{% set ptable = false %}{% endif %}
 {% if reboot_reset is undefined %}{% set reboot_reset = false %}{% endif %}
@@ -44,18 +43,8 @@ protocols:
     packages:
     - wget
     - unzip
-{% if install_packages == true %}
-    - abootimg
-    - android-tools-fsutils
-    - cpio
-    - curl
-    - e2fsprogs
-    - file
-    - git
-    - libguestfs-tools
-    - mkbootimg
-    - xz-utils
-{% endif %}
+{% block lxc_extra_packages %}
+{% endblock lxc_extra_packages %}
     os: debian
 
 - boot:

--- a/projects/lkft/fastboot.jinja2
+++ b/projects/lkft/fastboot.jinja2
@@ -4,6 +4,19 @@
 {% include PROJECT+"include/lkft-metadata.jinja2" %}
 {% endblock metadata %}
 
+{% block lxc_extra_packages %}
+    - android-tools-fsutils
+    - curl
+    - cpio
+    - file
+    - git
+    - libguestfs-tools
+    - linux-image-amd64
+    - mkbootimg
+    - xz-utils
+    - --no-install-recommends
+{% endblock lxc_extra_packages %}
+
 {% block deploy_target %}
 {{ super() }}
 {% if DEPLOY_TARGET == "download" %}

--- a/projects/lt-qcom/fastboot.jinja2
+++ b/projects/lt-qcom/fastboot.jinja2
@@ -1,5 +1,14 @@
 {% extends "fastboot.jinja2" %}
 
+{% block lxc_extra_packages %}
+    - abootimg
+    - android-tools-fsutils
+    - cpio
+    - e2fsprogs
+    - git
+    - --no-install-recommends
+{% endblock lxc_extra_packages %}
+
 {% block deploy_target %}
 {{ super() }}
 {% if rootfs == true %}


### PR DESCRIPTION
Simplify the fastboot.jinja2 by moving the extra packages that different
project need to install into the project specific fastboot.jinja2 file.

Remove the install_packages flag and use a block lxc_extra_packages
instead. Let the different project declare the package list they need.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>