### PR TITLE
testcases: delete ltp-syscalls-kasan

### DIFF
--- a/testcases/ltp-syscalls-kasan.yaml
+++ b/testcases/ltp-syscalls-kasan.yaml
@@ -1,5 +1,0 @@
-{% extends "testcases/master/template-ltp.yaml.jinja2" %}
-
-{% set testnames = ['syscalls'] %}
-{% set test_timeout = 120 %}
-{% set LAVA_TEST_NAME_SUFFIX = '-kasan' %}


### PR DESCRIPTION
Remove the ltp-syscalls-kasan testcase, since we can change the
LAVA_TEST_NAME_SUFFIX via variables.ini now.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>