### PR TITLE
Creating armnn-benchmarking.yaml

### DIFF
--- a/testcases/armnn-benchmarking.yaml
+++ b/testcases/armnn-benchmarking.yaml
@@ -1,0 +1,17 @@
+ 
+{% extends "testcases/master/template-master.jinja2" %}
+
+{% set test_timeout = 840 %}
+{% block metadata %}
+  {{ super() }}
+{% endblock metadata %}
+
+{% set test_name = "armnn" %}
+
+{% block test_target %}
+  {{ super() }}
+    - repository: https://github.com/Linaro/test-definitions.git
+      from: git
+      path: automated/linux/armnn-benchmarks/armnn-benchmarking.yaml
+      name: armnn-mlperf benchmark
+{% endblock test_target %}


### PR DESCRIPTION
armnn-ci-build: Creating armnn-benchmarking.yaml to run armnn mlperf benchmarking on debian devices.