### PR TITLE
armnn-ci-build: adding --no-check-certificate to testcases/armnn.yaml : snapshots.linaro.org…

### DIFF
--- a/testcases/armnn.yaml
+++ b/testcases/armnn.yaml
@@ -22,7 +22,7 @@
           steps:
           - dhclient
           - apt-get install -y ntp
-          - wget {{ ARMNN_TARBALL_URL }}
+          - wget --no-check-certificate {{ ARMNN_TARBALL_URL }}
           - tar xf armnn.tar.xz
           - cd home/buildslave/workspace/armnn-ci-build
           - export BASEDIR=`pwd`


### PR DESCRIPTION
…, as the certificate is marked not yet activated for dragonboard845c builds.