### PR TITLE
LTP: Adding sub test plan crypto

### DIFF
--- a/testcases/ltp-short-runs.yaml
+++ b/testcases/ltp-short-runs.yaml
@@ -1,4 +1,4 @@
 {% extends "testcases/master/template-ltp.yaml.jinja2" %}
 
-{% set testnames = ['cap_bounds', 'cpuhotplug', 'fcntl-locktests', 'filecaps', 'fs_bind', 'fs_perms_simple', 'fsx', 'nptl', 'pty', 'securebits'] %}
+{% set testnames = ['cap_bounds', 'cpuhotplug', 'crypto', 'fcntl-locktests', 'filecaps', 'fs_bind', 'fs_perms_simple', 'fsx', 'nptl', 'pty', 'securebits'] %}
 {% set test_timeout = 30 %}


### PR DESCRIPTION
Adding LTP sub test plan crypto as short run.
LTP crypto tested on arm64, arm and x86_64 and test takes
less than a minute to complete the run. so adding it to
ltp short run list.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>