### PR TITLE
ltp-cve: Remove spectre-meltdown-checker

### DIFF
--- a/testcases/ltp-cve.yaml
+++ b/testcases/ltp-cve.yaml
@@ -2,16 +2,3 @@
 
 {% set testnames = ['cve'] %}
 {% set test_timeout = 60 %}
-
-{% block metadata %}
-  {{ super() }}
-  spectre_meltdown_checker_test__url: "https://github.com/speed47/spectre-meltdown-checker.git"
-{% endblock metadata %}
-
-{% block test_target %}
-  {{ super() }}
-    - repository: https://github.com/Linaro/test-definitions.git
-      from: git
-      path: automated/linux/spectre-meltdown-checker-test/spectre-meltdown-checker-test.yaml
-      name: spectre-meltdown-checker-test
-{% endblock test_target %}


### PR DESCRIPTION
It's not a test as such, but more of an informational status of the machine on which the script runs.

Feedback from the community has been negative, so it's been decided it should be gone.