### PR TITLE
overlay_modules_*: fix indentation

### DIFF
--- a/fastboot.jinja2
+++ b/fastboot.jinja2
@@ -141,15 +141,15 @@ protocols:
 {% block rootfs_extra_args %}
 {% endblock rootfs_extra_args %}
 {% if OVERLAY_MODULES_URL is defined %}
-      overlays:
-        modules:
-          url: {{OVERLAY_MODULES_URL}}
-          path: /
+        overlays:
+          modules:
+            url: {{OVERLAY_MODULES_URL}}
+            path: /
 {% if OVERLAY_MODULES_URL_FORMAT is defined %}
-          format: {{OVERLAY_MODULES_URL_FORMAT}}
+            format: {{OVERLAY_MODULES_URL_FORMAT}}
 {% endif %}
 {% if OVERLAY_MODULES_URL_COMP is defined %}
-          compression: {{OVERLAY_MODULES_URL_COMP}}
+            compression: {{OVERLAY_MODULES_URL_COMP}}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/nfs.jinja2
+++ b/nfs.jinja2
@@ -60,15 +60,15 @@
 {% block rootfs_extra_args %}
 {% endblock rootfs_extra_args %}
 {% if OVERLAY_MODULES_URL is defined %}
-      overlays:
-        modules:
-          url: {{OVERLAY_MODULES_URL}}
-          path: /
+        overlays:
+          modules:
+            url: {{OVERLAY_MODULES_URL}}
+            path: /
 {% if OVERLAY_MODULES_URL_FORMAT is defined %}
-          format: {{OVERLAY_MODULES_URL_FORMAT}}
+            format: {{OVERLAY_MODULES_URL_FORMAT}}
 {% endif %}
 {% if OVERLAY_MODULES_URL_COMP is defined %}
-          compression: {{OVERLAY_MODULES_URL_COMP}}
+            compression: {{OVERLAY_MODULES_URL_COMP}}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/qemu.jinja2
+++ b/qemu.jinja2
@@ -89,15 +89,15 @@
 {% block rootfs_extra_args %}
 {% endblock rootfs_extra_args %}
 {% if OVERLAY_MODULES_URL is defined %}
-      overlays:
-        modules:
-          url: {{OVERLAY_MODULES_URL}}
-          path: /
+        overlays:
+          modules:
+            url: {{OVERLAY_MODULES_URL}}
+            path: /
 {% if OVERLAY_MODULES_URL_FORMAT is defined %}
-          format: {{OVERLAY_MODULES_URL_FORMAT}}
+            format: {{OVERLAY_MODULES_URL_FORMAT}}
 {% endif %}
 {% if OVERLAY_MODULES_URL_COMP is defined %}
-          compression: {{OVERLAY_MODULES_URL_COMP}}
+            compression: {{OVERLAY_MODULES_URL_COMP}}
 {% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
When trying to add OVERLAY_MODULES_* to a qemu job I see the following
LAVA JobError was printed:

  case: job
  case_id: 277150630
  definition: lava
  error_msg: Invalid deploy action: 'url' is missing for 'overlays'
  error_type: Job
  result: fail

Rework to add the correct indentation.

Fixes: 799b33bf141f ("add support for rootfs overlay modules")
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>