### PR TITLE
Updating armnn-benchmarking.yaml

### DIFF
--- a/testcases/armnn-benchmarking.yaml
+++ b/testcases/armnn-benchmarking.yaml
@@ -13,5 +13,5 @@
     - repository: https://github.com/Linaro/test-definitions.git
       from: git
       path: automated/linux/armnn-benchmarks/armnn-benchmarking.yaml
-      name: armnn-mlperf benchmark
+      name: armnn-mlperf-benchmark
 {% endblock test_target %}


### PR DESCRIPTION
armnn-ci-benchmarking: fixing invalid test name error.