### PR TITLE
lkft: devices: i386: add BOOT_OS_PROMPT

### DIFF
--- a/projects/lkft/devices/i386
+++ b/projects/lkft/devices/i386
@@ -1,1 +1,4 @@
-x86
+{% extends "devices/i386" %}
+
+{% set BOOT_OS_PROMPT = BOOT_OS_PROMPT|default("root@intel-core2-32:") %}
+{% set MODULES_URL_COMP = MODULES_URL_COMP|default("xz") %}


### PR DESCRIPTION
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>