### PR TITLE
LTP: split ltp short runs into three groups

### DIFF
--- a/testcases/ltp-short-runs-1.yaml
+++ b/testcases/ltp-short-runs-1.yaml
@@ -1,0 +1,4 @@
+{% extends "testcases/master/template-ltp.yaml.jinja2" %}
+
+{% set testnames = ['cap_bounds', 'cpuhotplug', 'crypto'] %}
+{% set test_timeout = 30 %}

--- a/testcases/ltp-short-runs-2.yaml
+++ b/testcases/ltp-short-runs-2.yaml
@@ -1,0 +1,4 @@
+{% extends "testcases/master/template-ltp.yaml.jinja2" %}
+
+{% set testnames = ['fcntl-locktests', 'filecaps', 'fs_bind', 'fs_perms_simple', 'fsx'] %}
+{% set test_timeout = 30 %}

--- a/testcases/ltp-short-runs-3.yaml
+++ b/testcases/ltp-short-runs-3.yaml
@@ -1,0 +1,4 @@
+{% extends "testcases/master/template-ltp.yaml.jinja2" %}
+
+{% set testnames = ['nptl', 'pty', 'securebits'] %}
+{% set test_timeout = 30 %}

--- a/testcases/ltp-short-runs.yaml
+++ b/testcases/ltp-short-runs.yaml
@@ -1,4 +1,0 @@
-{% extends "testcases/master/template-ltp.yaml.jinja2" %}
-
-{% set testnames = ['cap_bounds', 'cpuhotplug', 'crypto', 'fcntl-locktests', 'filecaps', 'fs_bind', 'fs_perms_simple', 'fsx', 'nptl', 'pty', 'securebits'] %}
-{% set test_timeout = 30 %}

--- a/testplans/lkft-full/ltp-short-runs-1.yaml
+++ b/testplans/lkft-full/ltp-short-runs-1.yaml
@@ -1,0 +1,1 @@
+../../testcases/ltp-short-runs-1.yaml

--- a/testplans/lkft-full/ltp-short-runs-2.yaml
+++ b/testplans/lkft-full/ltp-short-runs-2.yaml
@@ -1,0 +1,1 @@
+../../testcases/ltp-short-runs-2.yaml

--- a/testplans/lkft-full/ltp-short-runs-3.yaml
+++ b/testplans/lkft-full/ltp-short-runs-3.yaml
@@ -1,0 +1,1 @@
+../../testcases/ltp-short-runs-3.yaml

--- a/testplans/lkft-full/ltp-short-runs.yaml
+++ b/testplans/lkft-full/ltp-short-runs.yaml
@@ -1,1 +1,0 @@
-../../testcases/ltp-short-runs.yaml

--- a/testplans/lkft-ltp/ltp-short-runs-1.yaml
+++ b/testplans/lkft-ltp/ltp-short-runs-1.yaml
@@ -1,0 +1,1 @@
+../../testcases/ltp-short-runs-1.yaml

--- a/testplans/lkft-ltp/ltp-short-runs-2.yaml
+++ b/testplans/lkft-ltp/ltp-short-runs-2.yaml
@@ -1,0 +1,1 @@
+../../testcases/ltp-short-runs-2.yaml

--- a/testplans/lkft-ltp/ltp-short-runs-3.yaml
+++ b/testplans/lkft-ltp/ltp-short-runs-3.yaml
@@ -1,0 +1,1 @@
+../../testcases/ltp-short-runs-3.yaml

--- a/testplans/lkft-ltp/ltp-short-runs.yaml
+++ b/testplans/lkft-ltp/ltp-short-runs.yaml
@@ -1,1 +1,0 @@
-../../testcases/ltp-short-runs.yaml


### PR DESCRIPTION
LTP short run is design to run short run test cases from a single test job
but this is cause a problem when applying overlay on qemu and x15
and causing no space left on the device.

Spliting short runs into three groups solves this problem.

Reference link to problematic lava job runs,
https://lkft.validation.linaro.org/scheduler/job/1391178

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>