### PR TITLE
testplans: lkft-full: remove kvm-unit-tests

### DIFF
--- a/testplans/lkft-full/kvm-unit-tests.yaml
+++ b/testplans/lkft-full/kvm-unit-tests.yaml
@@ -1,1 +1,0 @@
-../../testcases/kvm-unit-tests.yaml


### PR DESCRIPTION
Remove kvm-unit-tests from all boards since we don't want to run
kvm-unit-tests on qemu "boards".

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>