### PR TITLE
LKFT: LAVA: Adding reboot_to_fastboot: false

### DIFF
--- a/fastboot.jinja2
+++ b/fastboot.jinja2
@@ -1,3 +1,5 @@
+reboot_to_fastboot: false
+
 {% extends "master.jinja2" %}
 
 {% set use_context = true %}


### PR DESCRIPTION
on LXC connected devices reboot devices to bootloader is
set to true and which is causing finalize timeout because
the device is already poweroff by that time.

Setting reboot_to_fastboot: false

Error logs before this patch,
  finalize timed out after 29 seconds
  finalize timed out after 1587143579 seconds
  finalize timed out after 29 seconds
  finalize timed out after 30 seconds

Test jobs after applying this patch works.
lava-lxc protocol: device not rebooting to fastboot

https://lkft.validation.linaro.org/scheduler/job/1426891/definition#defline1
https://lkft.validation.linaro.org/scheduler/job/1426887/definition#defline1

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>