### PR TITLE
devices: use part number to determine partition layout

### DIFF
--- a/devices/x15
+++ b/devices/x15
@@ -17,7 +17,8 @@
     - setenv fdtfile am57xx-beagle-x15.dtb
     - setenv console ttyS2,115200n8
     - setenv mmcdev 1
-    - "setenv bootpart 1:9"
+    - part number mmc 1 {{ rootfs_label }} part_num
+    - "setenv bootpart 1:${part_num}"
     - run mmcboot
 {% endblock boot_commands %}
 


### PR DESCRIPTION
When booting X15 board with non-android build it is required to provide
proper partition number to u-boot boot command. Fortunately u-boot
allows to query partition number with partition name - 'part number'
command. This patch adds 'part number' command to X15 boot sequence.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>