### PR TITLE
devices: x15: Use super partition instead of userdata

### DIFF
--- a/devices/x15
+++ b/devices/x15
@@ -8,7 +8,7 @@
 {# libhugetlbfs_word_size variable is required for libhugetlbfs.yaml test template #}
 {% set libhuggetlbfs_word_size = 32 %}
 {% set pre_os_command = false %}
-{% set rootfs_label = "userdata" %}
+{% set rootfs_label = "super" %}
 
 {% block device_type %}x15{% endblock %}
 


### PR DESCRIPTION
As of 5/20, X15 devices have a new U-boot and partition table which allow us to use this larger partition. This way, the same X15 boards can be shared between OE and Android.

Related: https://projects.linaro.org/browse/LSS-1312