### PR TITLE
LKFT: KVM: Bump GIT_REF to latest commit id

### DIFF
--- a/testcases/master/template-kvm-unit-tests.yaml.jinja2
+++ b/testcases/master/template-kvm-unit-tests.yaml.jinja2
@@ -21,5 +21,5 @@
       parameters:
         SKIP_INSTALL: 'true'
         SMP: {% if DEVICE_TYPE == "juno-r2" %}'false'{% else %}'true'{% endif %}
-        GIT_REF: "{{KVM_UNIT_TESTS_REVISION | default('40f559bc572e355cadef513ec41fe114e9a8394e')}}"
+        GIT_REF: "{{KVM_UNIT_TESTS_REVISION | default('4b74c718c57d1697e3228e2c699b0fe9c1d24e97')}}"
 {% endblock test_target %}


### PR DESCRIPTION
kvm-unit-tests version update to latest test sources by changing
GIT_REF commit id.

Tested on x86_64 and Juno devices.
https://lkft.validation.linaro.org/results/1504975
https://lkft.validation.linaro.org/results/1506165

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>