### PR TITLE
armnn-ci-build: stm32mp1 patch 1

### DIFF
--- a/devices/stm32mp1
+++ b/devices/stm32mp1
@@ -1,0 +1,29 @@
+{% set PROJECT = PROJECT|default("") %}
+{% extends PROJECT+"qemu.jinja2" %}
+
+{% set BOOT_OS_PROMPT = BOOT_OS_PROMPT|default("root@stm32mp1", "root@debian:~#") %}
+{% set DEPLOY_OS = DEPLOY_OS|default("oe") %}
+
+
+{% block deploy_target %}
+- deploy:
+    timeout:
+      minutes: {{ target_deploy_timeout }}
+    to: {{ DEPLOY_TARGET }}
+    namespace: target
+    images:
+      tarball: {{ TARBALL_URL }}
+      layout: {{ LAYOUT_URL }}
+    os: {{ DEPLOY_OS }}
+{% endblock deploy_target %}
+
+
+{% block boot_target %}
+- boot:
+    namespace: target
+{% include "include/boot_target/boot_os_prompt.jinja2" %}
+{% include "include/boot_target/timeout_and_method.jinja2" %}
+   transfer_overlay:
+     download_command: udhcpc; cd /tmp ; wget
+     unpack_command: tar -C / -xzf
+{% endblock boot_target %}

--- a/testcases/armnn32bit.yaml
+++ b/testcases/armnn32bit.yaml
@@ -38,3 +38,4 @@
       from: inline
       name: armnn
       path: inline/armnn.yaml
+{% endblock test_target %}

--- a/testcases/armnn32bit.yaml
+++ b/testcases/armnn32bit.yaml
@@ -9,7 +9,7 @@
 
 {% block test_target %}
   {{ super() }}
-     -repository:
+     - repository:
         metadata:
           format: Lava-Test Test Definition 1.0
           name: armnn-test

--- a/testcases/armnn32bit.yaml
+++ b/testcases/armnn32bit.yaml
@@ -25,7 +25,7 @@
           - apt-get install -y wget
           - mkdir /usr/local/bin
           - cd /usr/local/bin
-          - wget --no-check-certificate {{ ARMNN32_TARBALL_URL }}
+          - wget --no-check-certificate {{ ARMNN_TARBALL_URL }}
           - tar xf armnn32.tar.xz
           - cd home/theodore
           - export BASEDIR=`pwd`

--- a/testcases/armnn32bit.yaml
+++ b/testcases/armnn32bit.yaml
@@ -1,0 +1,40 @@
+{% extends "testcases/master/template-master.jinja2" %}
+
+{% set test_timeout = 30 %}
+{% block metadata %}
+  {{ super() }}
+{% endblock metadata %}
+
+{% set test_name = "armnn32bit" %}
+
+{% block test_target %}
+  {{ super() }}
+     -repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: armnn-test
+          os:
+          - debian
+          scope:
+          - functional
+        run:
+          steps:
+          - cd
+          - apt-get -y install ca-certificates
+          - apt-get -y update
+          - apt-get install -y wget
+          - mkdir /usr/local/bin
+          - cd /usr/local/bin
+          - wget --no-check-certificate {{ ARMNN32_TARBALL_URL }}
+          - tar xf armnn32.tar.xz
+          - cd home/theodore
+          - export BASEDIR=`pwd`
+          - mv $BASEDIR/armnn-pi $BASEDIR/armnn
+          - cd $BASEDIR/armnn/build
+          - ln -s libprotobuf.so.15.0.0 ./libprotobuf.so.15
+          - export LD_LIBRARY_PATH=`pwd`
+          - chmod a+x UnitTests
+          - ./UnitTests
+      from: inline
+      name: armnn
+      path: inline/armnn.yaml

--- a/testplans/armnn32bit/armnn32bit.yaml
+++ b/testplans/armnn32bit/armnn32bit.yaml
@@ -1,0 +1,1 @@
+../../testcases/armnn32bit.yaml


### PR DESCRIPTION
armnn-ci-build: adding device type stm32mp1 and files for deployment of 32bit armnn, fixing errors from previous commits.
