### PR TITLE
testcases: armnn: use test-definitions repo instead of inline

### DIFF
--- a/testcases/armnn.yaml
+++ b/testcases/armnn.yaml
@@ -9,29 +9,10 @@
 
 {% block test_target %}
   {{ super() }}
-    - repository:
-        metadata:
-          format: Lava-Test Test Definition 1.0
-          name: armnn test
-          description: "armnn test"
-          os:
-          - debian
-          scope:
-          - functional
-        run:
-          steps:
-          - dhclient
-          - apt-get install -y ntp
-          - wget --no-check-certificate {{ ARMNN_TARBALL_URL }}
-          - tar xf armnn.tar.xz
-          - cd home/buildslave/workspace/armnn-ci-build
-          - export BASEDIR=`pwd`
-          - cd $BASEDIR/build
-          - ln -s $BASEDIR/build/libprotobuf.so.15.0.0 ./libprotobuf.so.15
-          - export LD_LIBRARY_PATH=`pwd`
-          - chmod a+x UnitTests
-          - lava-test-case ArmNN-Unit-Tests --shell ./UnitTests
-      from: inline
-      name: armnn
-      path: inline/armnn.yaml
+    - repository: https://github.com/Linaro/test-definitions.git
+      from: git
+      path: automated/linux/armnn/armnn-unit-tests.yaml
+      name: armnn-unit-tests
+      parameters:
+              ARMNN_TARBALL: '{{ ARMNN_TARBALL_URL }}'
 {% endblock test_target %}


### PR DESCRIPTION
This will allow the ArmNN UnitTests to be run on 64bit and 32bit boards.

Signed-off-by: Theodore Grey <theodore.grey@linaro.org>