### PR TITLE
lkft: devices: juno-r2: growing kernel image

### DIFF
--- a/projects/lkft/devices/juno-r2
+++ b/projects/lkft/devices/juno-r2
@@ -6,6 +6,6 @@
 
 {% block context %}
   {{ super() }}
-  booti_dtb_addr: "0x85000000"
+  booti_dtb_addr: "0x86000000"
   extra_nfsroot_args: ',wsize=65536'
 {% endblock context %}


### PR DESCRIPTION
The kernel Image needs bigger so the dtb wont overwrite the
kernel.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>