### PR TITLE
Dockerfile: add curl and jq packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl \
+      jq \
       python3-pip \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This is two small packages that are useful to download and query json
files.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>