### PR TITLE
Dockerfile: remove cache dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       && rm -rf /var/lib/apt/lists/*
 
 COPY --from=git_builder /lava-test-plans /lava-test-plans
-RUN pip3 install -r /lava-test-plans/requirements.txt
+RUN pip3 install --no-cache-dir -r /lava-test-plans/requirements.txt


### PR DESCRIPTION
By adding the flag to remove cache dirs makes the container smaller.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>