### PR TITLE
testcases: fix u-boot version string

### DIFF
--- a/testcases/u-boot.yaml
+++ b/testcases/u-boot.yaml
@@ -28,7 +28,7 @@
       - command: version
         name: version
         successes:
-        - message: {{ UBOOT_VERSION_STRING|default("U-Boot") }}
+        - message: '{{ UBOOT_VERSION_STRING|default("U-Boot") }}'
       - command: help test
         name: help
         successes:


### PR DESCRIPTION
This patch makes sure that the version string is a string. When using
2020.10 LAVA considers it a float which is not allowed.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>