### PR TITLE
testcases: ltp-open-posix: fix extends bug

### DIFF
--- a/testcases/ltp-open-posix.yaml
+++ b/testcases/ltp-open-posix.yaml
@@ -1,4 +1,4 @@
-{% extends "testcases/master/template-master.jinja2" %}
+{% extends "testcases/master/template-test.jinja2" %}
 
 {% set test_timeout = 75 %}
 {% block metadata %}


### PR DESCRIPTION
Exteded with ltp-open-posix with template-master when it should have
been extended with template-test.

Fixes: 8e27a6c701ab ("testcases: ltp-open-posix: extend template-master")
Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>