### PR TITLE
testplans: lkft-full: remove ltp-tracing

### DIFF
--- a/testplans/lkft-full/ltp-tracing.yaml
+++ b/testplans/lkft-full/ltp-tracing.yaml
@@ -1,1 +1,0 @@
-../../testcases/ltp-tracing.yaml

--- a/testplans/lkft-ltp/ltp-tracing.yaml
+++ b/testplans/lkft-ltp/ltp-tracing.yaml
@@ -1,1 +1,0 @@
-../../testcases/ltp-tracing.yaml


### PR DESCRIPTION
Should only be running on 5.4 kernel and later.

Suggested-by: Naresh Kamboju <naresh.kamboju@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>