### PR TITLE
testcases: kselftest timeout increased to 85 minutes

### DIFF
--- a/testcases/ltp-cve.yaml
+++ b/testcases/ltp-cve.yaml
@@ -2,3 +2,4 @@
 
 {% set testnames = ['cve'] %}
 {% set test_timeout = 60 %}
+{% set TIMEOUT_MULTIPLIER = 1 %}

--- a/testcases/master/template-kselftest.yaml.jinja2
+++ b/testcases/master/template-kselftest.yaml.jinja2
@@ -12,7 +12,7 @@
 
 {% extends "testcases/master/template-master.jinja2" %}
 
-{% set test_timeout = 55 %}
+{% set test_timeout = 85 %}
 {% block metadata %}
   {{ super() }}
   kselftest__url: "{{KSELFTESTS_URL | default('unknown')}}"

--- a/testcases/master/template-ltp.yaml.jinja2
+++ b/testcases/master/template-ltp.yaml.jinja2
@@ -30,7 +30,7 @@
         BOARD: '{{ DEVICE_TYPE }}'
         BRANCH: '{{ SKIPGEN_KERNEL_VERSION|default('default') }}'
         ENVIRONMENT: '{{ ENVIRONMENT|default('production') }}'
-        TIMEOUT_MULTIPLIER: 3
+        TIMEOUT_MULTIPLIER: '{{ TIMEOUT_MULTIPLIER|default('3') }}'
         LTP_TMPDIR: '/scratch'
       name: ltp-{{testname}}{{LAVA_TEST_NAME_SUFFIX}}-tests
 {% endfor %}


### PR DESCRIPTION
kselftest sources updated to stable 5.9 and this comes with new test cases
which need 30 minutes more run time. so increasing the timeout to 85 minutes.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>