### PR TITLE
docker: remove 'local: true'

### DIFF
--- a/fastboot.jinja2
+++ b/fastboot.jinja2
@@ -8,7 +8,6 @@
     to: fastboot
     docker:
       image: {{DOCKER_IMAGE}}
-      local: true
     images:
 {% if ptable == true %}
       ptable:

--- a/include/fastboot.jinja2
+++ b/include/fastboot.jinja2
@@ -116,7 +116,6 @@ reboot_to_fastboot: {{ reboot_to_fastboot }}
     postprocess:
       docker:
         image: {{DOCKER_IMAGE}}
-        local: true
 {% endblock deploy_target %}
 
 {% block pre_boot_command %}

--- a/projects/lkft/fastboot.jinja2
+++ b/projects/lkft/fastboot.jinja2
@@ -22,7 +22,6 @@
     to: fastboot
     docker:
       image: {{DOCKER_IMAGE}}
-      local: true
     images:
 {% if ptable == true %}
       ptable:


### PR DESCRIPTION
No need to set 'local: true' anymore, solved the rate limit issue.
If the 'local: true' there will be problem with new dispatches that
doesn't have the docker image cached locally.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>