### PR TITLE
lkft: fastboot: use the PTABLE_LABEL

### DIFF
--- a/projects/lkft/fastboot.jinja2
+++ b/projects/lkft/fastboot.jinja2
@@ -24,7 +24,7 @@
       image: {{DOCKER_IMAGE}}
     images:
 {% if ptable == true %}
-      ptable:
+      {{ PTABLE_LABEL }}:
         url: downloads://{{DOCKER_PTABLE_FILE}}
 {% if reboot_reset == true %}
         reboot: hard-reset


### PR DESCRIPTION
If creating a job file for db845c that have 'ptable = true' and
PTABLE_LABEL set to 'partition:0', this need to be used in the deploy
step 'to: fastboot' too.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>