### PR TITLE
Docker: move to Linaro based kir image

### DIFF
--- a/projects/lkft/fastboot.jinja2
+++ b/projects/lkft/fastboot.jinja2
@@ -5,7 +5,7 @@
 {% endblock metadata %}
 
 {% set DEPLOY_TARGET = DEPLOY_TARGET|default("downloads") %}
-{% set DOCKER_IMAGE = DOCKER_IMAGE|default("roxell/kir") %}
+{% set DOCKER_IMAGE = DOCKER_IMAGE|default("linaro/kir") %}
 {% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("ptable-linux-8g.img") %}
 {% set DOCKER_BOOT_FILE = DOCKER_BOOT_FILE|default("boot.img") %}
 {% set DOCKER_ROOTFS_FILE = DOCKER_ROOTFS_FILE|default("rpb-console-image-lkft.rootfs.img") %}

--- a/projects/lt-qcom/fastboot.jinja2
+++ b/projects/lt-qcom/fastboot.jinja2
@@ -1,7 +1,7 @@
 {% extends "include/fastboot.jinja2" %}
 
 {% set DEPLOY_TARGET = DEPLOY_TARGET|default("downloads") %}
-{% set DOCKER_IMAGE = DOCKER_IMAGE|default("roxell/kir") %}
+{% set DOCKER_IMAGE = DOCKER_IMAGE|default("linaro/kir") %}
 
 {% block deploy_target %}
 {{ super() }}


### PR DESCRIPTION
We now publish the kir docker image on the Linaro dockerhub account. So
we should pull from there.

Signed-off-by: Benjamin Copeland <ben.copeland@linaro.org>