### PR TITLE
lkft: devices: db845: set BOOT_LABEL to kernel

### DIFF
--- a/projects/lkft/devices/dragonboard-845c
+++ b/projects/lkft/devices/dragonboard-845c
@@ -1,5 +1,7 @@
 {% extends "devices/dragonboard-845c" %}
 
+{% set BOOT_LABEL = "kernel" %}
+{% set BOOT_LABEL_OVERRIDE = true %}
 {% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("gpt_both0.bin") %}
 {% set PTABLE_URL = PTABLE_URL|default("https://images.validation.linaro.org/snapshots.linaro.org/96boards/dragonboard845c/linaro/rescue/28/dragonboard-845c-bootloader-ufs-linux-28/gpt_both0.bin") %}
 {% set MODULES_URL_COMP = MODULES_URL_COMP|default("xz") %}

--- a/projects/lkft/fastboot.jinja2
+++ b/projects/lkft/fastboot.jinja2
@@ -4,6 +4,7 @@
 {% include PROJECT+"include/lkft-metadata.jinja2" %}
 {% endblock metadata %}
 
+{% set BOOT_LABEL_OVERRIDE = BOOT_LABEL_OVERRIDE|default(false) %}
 {% set DEPLOY_TARGET = DEPLOY_TARGET|default("downloads") %}
 {% set DOCKER_IMAGE = DOCKER_IMAGE|default("linaro/kir") %}
 {% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("ptable-linux-8g.img") %}
@@ -30,7 +31,7 @@
         reboot: hard-reset
 {% endif %}
 {% endif %}
-{% if boot == true and BOOT_LABEL != "kernel" %}
+{% if boot == true and BOOT_LABEL != "kernel" or BOOT_LABEL_OVERRIDE == true %}
       boot:
         url: downloads://{{DOCKER_BOOT_FILE}}
 {% if reboot_reset == true %}


### PR DESCRIPTION
db845c don't need the boot image to be passed in, since that gets
created in docker (kir) Image.gz+dtb.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>