### PR TITLE
README: Use GitHub actions workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/Linaro/lava-test-plans.svg?branch=master)](https://travis-ci.org/Linaro/lava-test-plans)
+![Build Status](https://github.com/Linaro/lava-test-plans/actions/workflows/test-plans-pipeline.yml/badge.svg)
+![REUSE Compliance Check](https://github.com/Linaro/lava-test-plans/actions/workflows/reuse.yml/badge.svg)
 
 # Installation
 


### PR DESCRIPTION
Updating our README to use GitHub workflow status, instead of TravisCI
as this is no longer used.

Signed-off-by: Benjamin Copeland <ben.copeland@linaro.org>