### PR TITLE
lkft: devices: qemu_arm64: set qemu_arm virt to 2.10

### DIFF
--- a/projects/lkft/devices/qemu_arm64
+++ b/projects/lkft/devices/qemu_arm64
@@ -3,3 +3,6 @@
 {% set ROOTFS_URL_FORMAT = ROOTFS_URL_FORMAT|default("ext4") %}
 {% set OVERLAY_MODULES_URL_FORMAT = OVERLAY_MODULES_URL_FORMAT|default("tar") %}
 {% set OVERLAY_MODULES_URL_COMP = OVERLAY_MODULES_URL_COMP|default("xz") %}
+{% if DEVICE_TYPE == 'qemu_arm' %}
+{% set GS_MACHINE = "virt-2.10,accel=kvm" %}
+{% endif %}


### PR DESCRIPTION
Running on host arm64, running qemu_arm guest with QEMU version
'qemu-system-arm/stable,stable,now 1:3.1+dfsg-8+deb10u8 arm64' with
'virt,accel=kvm' the kernel doesn't boot with failure 'VFS: Cannot open
root device \"vda\" or unknown-block(0,0): error -6'.

Reenable qemu_arm to use 'virt-2.10,accel=kvm' to get it to boot.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>