### PR TITLE
projects/lt-qcom: dragonboard-410c update VIDEO_DEVICES

### DIFF
--- a/projects/lt-qcom/devices/dragonboard-410c
+++ b/projects/lt-qcom/devices/dragonboard-410c
@@ -1,3 +1,3 @@
 {% extends "devices/dragonboard-410c" %}
 
-{% set VIDEO_DEVICES = VIDEO_DEVICES|default({"/dev/video0": "venus-encoder", "/dev/video1": "venus-decoder"}) %}
+{% set VIDEO_DEVICES = VIDEO_DEVICES|default({"/dev/video0": "camss-0", "/dev/video1": "camss-1", "/dev/video2": "camss-2", "/dev/video3": "camss-3", "/dev/video4": "venus-encoder", "/dev/video5": "venus-decoder"}) %}


### PR DESCRIPTION
Now camss is supported in mainline so update VIDEO_DEVICES to have camss
+ venus v4l2 devices.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>