### PR TITLE
testcases: split up kselftest in different jobs

### DIFF
--- a/devices/qemu_arm64
+++ b/devices/qemu_arm64
@@ -11,6 +11,7 @@
   netdevice: tap
   machine: {{ GS_MACHINE }}
   cpu: host{% if DEVICE_TYPE == 'qemu_arm' %},aarch64=off{% endif %}
+  guestfs_size: {{ guestfs_size|default(512) }}
 {% endblock global_settings %}
 
 {% block device_type %}qemu-arm{% endblock %}

--- a/devices/qemu_i386
+++ b/devices/qemu_i386
@@ -11,6 +11,7 @@
 {% block global_settings %}
 {{ super() }}
   arch: i386
+  guestfs_size: {{ guestfs_size|default(512) }}
 {% endblock global_settings %}
 
 {% block device_type %}qemu{% endblock %}

--- a/devices/qemu_x86_64
+++ b/devices/qemu_x86_64
@@ -8,6 +8,7 @@
 {% block global_settings %}
 {{ super() }}
   arch: amd64
+  guestfs_size: {{ guestfs_size|default(512) }}
 {% endblock global_settings %}
 
 {% block device_type %}qemu{% endblock %}

--- a/nfs.jinja2
+++ b/nfs.jinja2
@@ -44,6 +44,18 @@
 {% if MODULES_URL_COMP is defined %}
       compression: {{MODULES_URL_COMP}}
 {% endif %}
+{% if OVERLAY_KSELFTEST_URL is defined %}
+    overlays:
+      kselftest:
+        url: {{OVERLAY_KSELFTEST_URL}}
+        path: {{KSELFTEST_PATH|default("/opt/kselftest_intree")}}
+{% if OVERLAY_KSELFTEST_URL_FORMAT is defined %}
+        format: {{OVERLAY_KSELFTEST_URL_FORMAT}}
+{% endif %}
+{% if OVERLAY_KSELFTEST_URL_COMP is defined %}
+        compression: {{OVERLAY_KSELFTEST_URL_COMP}}
+{% endif %}
+{% endif %}
 {% endif %}
 {% if OPTEE_URL is defined %}
     optee:

--- a/projects/lkft/devices/qemu_arm64
+++ b/projects/lkft/devices/qemu_arm64
@@ -1,6 +1,8 @@
 {% extends "devices/qemu_arm64" %}
 
 {% set ROOTFS_URL_FORMAT = ROOTFS_URL_FORMAT|default("ext4") %}
+{% set OVERLAY_KSELFTEST_URL_FORMAT = OVERLAY_KSELFTEST_URL_FORMAT|default("tar") %}
+{% set OVERLAY_KSELFTEST_URL_COMP = OVERLAY_KSELFTEST_URL_COMP|default("xz") %}
 {% set OVERLAY_MODULES_URL_FORMAT = OVERLAY_MODULES_URL_FORMAT|default("tar") %}
 {% set OVERLAY_MODULES_URL_COMP = OVERLAY_MODULES_URL_COMP|default("xz") %}
 {% if DEVICE_TYPE == 'qemu_arm' %}

--- a/projects/lkft/devices/qemu_i386
+++ b/projects/lkft/devices/qemu_i386
@@ -1,5 +1,7 @@
 {% extends "devices/qemu_i386" %}
 
 {% set ROOTFS_URL_FORMAT = ROOTFS_URL_FORMAT|default("ext4") %}
+{% set OVERLAY_KSELFTEST_URL_FORMAT = OVERLAY_KSELFTEST_URL_FORMAT|default("tar") %}
+{% set OVERLAY_KSELFTEST_URL_COMP = OVERLAY_KSELFTEST_URL_COMP|default("xz") %}
 {% set OVERLAY_MODULES_URL_FORMAT = OVERLAY_MODULES_URL_FORMAT|default("tar") %}
 {% set OVERLAY_MODULES_URL_COMP = OVERLAY_MODULES_URL_COMP|default("xz") %}

--- a/projects/lkft/devices/qemu_x86_64
+++ b/projects/lkft/devices/qemu_x86_64
@@ -1,5 +1,7 @@
 {% extends "devices/qemu_x86_64" %}
 
 {% set ROOTFS_URL_FORMAT = ROOTFS_URL_FORMAT|default("ext4") %}
+{% set OVERLAY_KSELFTEST_URL_FORMAT = OVERLAY_KSELFTEST_URL_FORMAT|default("tar") %}
+{% set OVERLAY_KSELFTEST_URL_COMP = OVERLAY_KSELFTEST_URL_COMP|default("xz") %}
 {% set OVERLAY_MODULES_URL_FORMAT = OVERLAY_MODULES_URL_FORMAT|default("tar") %}
 {% set OVERLAY_MODULES_URL_COMP = OVERLAY_MODULES_URL_COMP|default("xz") %}

--- a/qemu.jinja2
+++ b/qemu.jinja2
@@ -90,8 +90,10 @@
 {% endif %}
 {% block rootfs_extra_args %}
 {% endblock rootfs_extra_args %}
-{% if OVERLAY_MODULES_URL is defined %}
+{% if OVERLAY_MODULES_URL is defined or OVERLAY_KSELFTEST_URL is defined%}
         overlays:
+{% endif %}
+{% if OVERLAY_MODULES_URL is defined %}
           modules:
             url: {{OVERLAY_MODULES_URL}}
             path: /
@@ -100,6 +102,17 @@
 {% endif %}
 {% if OVERLAY_MODULES_URL_COMP is defined %}
             compression: {{OVERLAY_MODULES_URL_COMP}}
+{% endif %}
+{% endif %}
+{% if OVERLAY_KSELFTEST_URL is defined %}
+          kselftest:
+            url: {{OVERLAY_KSELFTEST_URL}}
+            path: {{KSELFTEST_PATH|default("/opt/kselftest_intree")}}
+{% if OVERLAY_KSELFTEST_URL_FORMAT is defined %}
+            format: {{OVERLAY_KSELFTEST_URL_FORMAT}}
+{% endif %}
+{% if OVERLAY_KSELFTEST_URL_COMP is defined %}
+            compression: {{OVERLAY_KSELFTEST_URL_COMP}}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/testcases/kselftests-bpf.yaml
+++ b/testcases/kselftests-bpf.yaml
@@ -1,0 +1,4 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set testnames = ['bpf'] %}
+{% set test_timeout = 15 %}

--- a/testcases/kselftests-intel-x86.yaml
+++ b/testcases/kselftests-intel-x86.yaml
@@ -1,0 +1,4 @@
+{% extends "testcases/master/template-kselftest.yaml.jinja2" %}
+
+{% set testnames = ['intel_pstate', 'livepatch', 'ptrace', 'x86'] %}
+{% set test_timeout = 15 %}

--- a/testcases/kselftests-kvm.yaml
+++ b/testcases/kselftests-kvm.yaml
@@ -1,0 +1,4 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set testnames = ['kvm'] %}
+{% set test_timeout = 15 %}

--- a/testcases/kselftests-lkdtm.yaml
+++ b/testcases/kselftests-lkdtm.yaml
@@ -1,0 +1,4 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set testnames = ['lkdtm'] %}
+{% set test_timeout = 10 %}

--- a/testcases/kselftests-native.yaml
+++ b/testcases/kselftests-native.yaml
@@ -1,3 +1,5 @@
 {% extends "testcases/master/template-kselftest.yaml.jinja2" %}
 
+{% set testnames = [''] %}
+{% set test_timeout = 85 %}
 {% set vsyscall_mode = 'native' %}

--- a/testcases/kselftests-net.yaml
+++ b/testcases/kselftests-net.yaml
@@ -1,0 +1,4 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set testnames = ['net', 'netfilter', 'nsfs', 'tc-testing'] %}
+{% set test_timeout = 15 %}

--- a/testcases/kselftests-none.yaml
+++ b/testcases/kselftests-none.yaml
@@ -1,3 +1,5 @@
 {% extends "testcases/master/template-kselftest.yaml.jinja2" %}
 
+{% set testnames = [''] %}
+{% set test_timeout = 85 %}
 {% set vsyscall_mode = 'none' %}

--- a/testcases/kselftests-short-run-1.yaml
+++ b/testcases/kselftests-short-run-1.yaml
@@ -1,4 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
+{% set guestfs_size = 1024 %}
 {% set testnames = ['android', 'breakpoints', 'capabilities', 'cgroup', 'clone3', 'core', 'cpufreq', 'cpu-hotplug', 'drivers'] %}
 {% set test_timeout = 20 %}

--- a/testcases/kselftests-short-run-1.yaml
+++ b/testcases/kselftests-short-run-1.yaml
@@ -1,0 +1,4 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set testnames = ['android', 'breakpoints', 'capabilities', 'cgroup', 'clone3', 'core', 'cpufreq', 'cpu-hotplug', 'drivers'] %}
+{% set test_timeout = 20 %}

--- a/testcases/kselftests-short-run-2.yaml
+++ b/testcases/kselftests-short-run-2.yaml
@@ -1,4 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
+{% set guestfs_size = 1024 %}
 {% set testnames = ['efivarfs', 'filesystems', 'firmware', 'fpu', 'ftrace', 'futex', 'gpio', 'ipc', 'ir', 'kcmp', 'kexec'] %}
 {% set test_timeout = 20 %}

--- a/testcases/kselftests-short-run-2.yaml
+++ b/testcases/kselftests-short-run-2.yaml
@@ -1,0 +1,4 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set testnames = ['efivarfs', 'filesystems', 'firmware', 'fpu', 'ftrace', 'futex', 'gpio', 'ipc', 'ir', 'kcmp', 'kexec'] %}
+{% set test_timeout = 20 %}

--- a/testcases/kselftests-short-run-3.yaml
+++ b/testcases/kselftests-short-run-3.yaml
@@ -1,4 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
+{% set guestfs_size = 1024 %}
 {% set testnames = ['lib', 'membarrier', 'memfd', 'memory-hotplug', 'mincore', 'mount', 'mqueue', 'openat2', 'pidfd', 'pid_namespace', 'pstore', 'proc'] %}
 {% set test_timeout = 15 %}

--- a/testcases/kselftests-short-run-3.yaml
+++ b/testcases/kselftests-short-run-3.yaml
@@ -1,0 +1,4 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set testnames = ['lib', 'membarrier', 'memfd', 'memory-hotplug', 'mincore', 'mount', 'mqueue', 'openat2', 'pidfd', 'pid_namespace', 'pstore', 'proc'] %}
+{% set test_timeout = 15 %}

--- a/testcases/kselftests-short-run-4.yaml
+++ b/testcases/kselftests-short-run-4.yaml
@@ -1,0 +1,4 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set testnames = ['rseq', 'rtc', 'seccomp', 'sigaltstack', 'size', 'splice', 'static_keys', 'sync', 'sysctl'] %}
+{% set test_timeout = 15 %}

--- a/testcases/kselftests-short-run-4.yaml
+++ b/testcases/kselftests-short-run-4.yaml
@@ -1,4 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
+{% set guestfs_size = 1024 %}
 {% set testnames = ['rseq', 'rtc', 'seccomp', 'sigaltstack', 'size', 'splice', 'static_keys', 'sync', 'sysctl'] %}
 {% set test_timeout = 15 %}

--- a/testcases/kselftests-short-run-5.yaml
+++ b/testcases/kselftests-short-run-5.yaml
@@ -1,0 +1,4 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set testnames = ['timens', 'timers', 'tmpfs', 'tpm2', 'user', 'vm', 'zram'] %}
+{% set test_timeout = 20 %}

--- a/testcases/kselftests-short-run-5.yaml
+++ b/testcases/kselftests-short-run-5.yaml
@@ -1,4 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
+{% set guestfs_size = 1024 %}
 {% set testnames = ['timens', 'timers', 'tmpfs', 'tpm2', 'user', 'vm', 'zram'] %}
 {% set test_timeout = 20 %}

--- a/testcases/kselftests.yaml
+++ b/testcases/kselftests.yaml
@@ -1,2 +1,4 @@
 {% extends "testcases/master/template-kselftest.yaml.jinja2" %}
 
+{% set testnames = [''] %}
+{% set test_timeout = 85 %}

--- a/testcases/master/template-kselftest.yaml.jinja2
+++ b/testcases/master/template-kselftest.yaml.jinja2
@@ -4,7 +4,7 @@
 {%- if vsyscall_mode is defined %}
   {%- set vsyscall_suffix = "-vsyscall-mode-"+vsyscall_mode %}
 {%- endif -%}
-{% set test_name = "kselftests" + vsyscall_suffix %}
+{% set test_name = "kselftests" + testnames|join('-') + vsyscall_suffix %}
 {% set use_context = true %}
 {% if vsyscall_mode is defined %}
 {% set extra_kernel_args = 'vsyscall={{vsyscall_mode}} ' + extra_kernel_args|default("") %}
@@ -12,12 +12,13 @@
 
 {% extends "testcases/master/template-master.jinja2" %}
 
-{% set test_timeout = 85 %}
 {% block metadata %}
   {{ super() }}
-  kselftest__url: "{{KSELFTESTS_URL | default('unknown')}}"
-  kselftest__version: "{{KSELFTESTS_VERSION | default('unknown')}}"
-  kselftest__revision: "{{KSELFTESTS_REVISION | default('unknown')}}"
+{% for testname in testnames %}
+  kselftest-{{testname}}__url: "{{KSELFTESTS_URL | default('unknown')}}"
+  kselftest-{{testname}}__version: "{{KSELFTESTS_VERSION | default('unknown')}}"
+  kselftest-{{testname}}__revision: "{{KSELFTESTS_REVISION | default('unknown')}}"
+{% endfor %}
 {% endblock metadata %}
 
 {% block test_target %}
@@ -33,15 +34,18 @@
           - systemctl stop systemd-timesyncd || true
       name: timesync-off
       path: inline/timesync-off.yaml
+{% for testname in testnames %}
     - repository: {{ TEST_DEFINITIONS_REPOSITORY }}
       from: git
       revision: '{{ TDEFINITIONS_REVISION }}'
       path: automated/linux/kselftest/kselftest.yaml
-      name: kselftest{{vsyscall_suffix}}
+      name: kselftest-{{testname}}{{vsyscall_suffix}}
       parameters:
+        TST_CMDFILES: '{{testname}}'
         KSELFTEST_PATH: {{KSELFTEST_PATH}}
         SKIPFILE: skipfile-lkft.yaml
         BOARD: '{{ DEVICE_TYPE }}'
         BRANCH: '{{ SKIPGEN_KERNEL_VERSION|default('default') }}'
         ENVIRONMENT: '{{ ENVIRONMENT|default("production") }}'
+{% endfor %}
 {% endblock test_target %}

--- a/testplans/lkft-kselftest/kselftests-kvm.yaml
+++ b/testplans/lkft-kselftest/kselftests-kvm.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-kvm.yaml

--- a/testplans/lkft-kselftest/kselftests-lkdtm.yaml
+++ b/testplans/lkft-kselftest/kselftests-lkdtm.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-lkdtm.yaml

--- a/testplans/lkft-kselftest/kselftests-net.yaml
+++ b/testplans/lkft-kselftest/kselftests-net.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-net.yaml

--- a/testplans/lkft-kselftest/kselftests-short-run-1.yaml
+++ b/testplans/lkft-kselftest/kselftests-short-run-1.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-short-run-1.yaml

--- a/testplans/lkft-kselftest/kselftests-short-run-2.yaml
+++ b/testplans/lkft-kselftest/kselftests-short-run-2.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-short-run-2.yaml

--- a/testplans/lkft-kselftest/kselftests-short-run-3.yaml
+++ b/testplans/lkft-kselftest/kselftests-short-run-3.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-short-run-3.yaml

--- a/testplans/lkft-kselftest/kselftests-short-run-4.yaml
+++ b/testplans/lkft-kselftest/kselftests-short-run-4.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-short-run-4.yaml

--- a/testplans/lkft-kselftest/kselftests-short-run-5.yaml
+++ b/testplans/lkft-kselftest/kselftests-short-run-5.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-short-run-5.yaml


### PR DESCRIPTION
Add different testcases for kselftest.
This makes it quicker to run kselftest when you can run different jobs
on different machines at the same time.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>