### PR TITLE
testcases: Adding new test case packetdrill

### DIFF
--- a/testcases/packetdrill.yaml
+++ b/testcases/packetdrill.yaml
@@ -1,0 +1,13 @@
+{% extends "testcases/master/template-test.jinja2" %}
+
+{% set test_name = test_name | default("packetdrill") %}
+{% set test_path_file = 'automated/linux/packetdrill/packetdrill.yaml' %}
+{% set test_dir = '/opt/packetdrill/' %}
+{% set test_timeout = test_timeout | default(15) %}
+
+{% block test_target %}
+  {{ super() }}
+      parameters:
+        SKIP_INSTALL: "true"
+        TEST_DIR: '{{test_dir}}'
+{% endblock test_target %}


### PR DESCRIPTION
Adding new networking test case packetdrill.
This will improve test coverage of kernel network sub system.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>