### PR TITLE
testcases: split kselftests into short runs

### DIFF
--- a/testcases/kselftests-android.yaml
+++ b/testcases/kselftests-android.yaml
@@ -1,0 +1,5 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set guestfs_size = 1024 %}
+{% set testnames = ['android'] %}
+{% set test_timeout = 10 %}

--- a/testcases/kselftests-drivers.yaml
+++ b/testcases/kselftests-drivers.yaml
@@ -1,0 +1,5 @@
+{% extends "master/template-kselftest.yaml.jinja2" %}
+
+{% set guestfs_size = 1024 %}
+{% set testnames = ['drivers'] %}
+{% set test_timeout = 10 %}

--- a/testcases/kselftests-short-run-2.yaml
+++ b/testcases/kselftests-short-run-2.yaml
@@ -1,5 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set guestfs_size = 1024 %}
-{% set testnames = ['efivarfs', 'filesystems', 'firmware', 'fpu', 'ftrace', 'futex', 'gpio', 'ipc', 'ir', 'kcmp', 'kexec'] %}
+{% set testnames = ['efivarfs', 'filesystems', 'firmware', 'fpu', 'ftrace', 'futex'] %}
 {% set test_timeout = 20 %}

--- a/testcases/kselftests-short-run-3.yaml
+++ b/testcases/kselftests-short-run-3.yaml
@@ -1,5 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set guestfs_size = 1024 %}
-{% set testnames = ['lib', 'membarrier', 'memfd', 'memory-hotplug', 'mincore', 'mount', 'mqueue', 'openat2', 'pidfd', 'pid_namespace', 'pstore', 'proc'] %}
+{% set testnames = ['lib', 'membarrier', 'memfd', 'memory-hotplug', 'mincore', 'mount', 'mqueue'] %}
 {% set test_timeout = 15 %}

--- a/testcases/kselftests-short-run-4.yaml
+++ b/testcases/kselftests-short-run-4.yaml
@@ -1,5 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set guestfs_size = 1024 %}
-{% set testnames = ['rseq', 'rtc', 'seccomp', 'sigaltstack', 'size', 'splice', 'static_keys', 'sync', 'sysctl'] %}
+{% set testnames = ['seccomp', 'sigaltstack', 'size', 'splice', 'static_keys', 'sync', 'sysctl'] %}
 {% set test_timeout = 15 %}

--- a/testcases/kselftests-short-run-6.yaml
+++ b/testcases/kselftests-short-run-6.yaml
@@ -1,5 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set guestfs_size = 1024 %}
-{% set testnames = ['breakpoints', 'capabilities', 'cgroup', 'clone3', 'core', 'cpufreq', 'cpu-hotplug'] %}
+{% set testnames = ['openat2', 'pidfd', 'pid_namespace', 'pstore', 'proc'] %}
 {% set test_timeout = 20 %}

--- a/testcases/kselftests-short-run-7.yaml
+++ b/testcases/kselftests-short-run-7.yaml
@@ -1,5 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set guestfs_size = 1024 %}
-{% set testnames = ['breakpoints', 'capabilities', 'cgroup', 'clone3', 'core', 'cpufreq', 'cpu-hotplug'] %}
+{% set testnames = ['gpio', 'ipc', 'ir', 'kcmp', 'kexec','rseq', 'rtc'] %}
 {% set test_timeout = 20 %}

--- a/testplans/lkft-kselftest/kselftests-android.yaml
+++ b/testplans/lkft-kselftest/kselftests-android.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-android.yaml

--- a/testplans/lkft-kselftest/kselftests-drivers.yaml
+++ b/testplans/lkft-kselftest/kselftests-drivers.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-drivers.yaml

--- a/testplans/lkft-kselftest/kselftests-short-run-6.yaml
+++ b/testplans/lkft-kselftest/kselftests-short-run-6.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-short-run-6.yaml

--- a/testplans/lkft-kselftest/kselftests-short-run-7.yaml
+++ b/testplans/lkft-kselftest/kselftests-short-run-7.yaml
@@ -1,0 +1,1 @@
+../../testcases/kselftests-short-run-7.yaml


### PR DESCRIPTION
The overlay size is not enough for more than 7 test definitions
so spliting test cases into small short runs.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>