### PR TITLE
devices: qemu_arm64: make arch type a variable

### DIFF
--- a/devices/qemu_arm64
+++ b/devices/qemu_arm64
@@ -4,10 +4,11 @@
 {% set DEPLOY_OS = DEPLOY_OS|default("oe") %}
 {% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("gz") %}
 {% set GS_MACHINE = GS_MACHINE|default("virt,accel=kvm") %}
+{% set QEMU_ARCH = QEMU_ARCH|default("arm64") %}
 
 {% block global_settings %}
 {{ super() }}
-  arch: arm64
+  arch: {{ QEMU_ARCH }}
   netdevice: tap
   machine: {{ GS_MACHINE }}
   cpu: host{% if DEVICE_TYPE == 'qemu_arm' %},aarch64=off{% endif %}


### PR DESCRIPTION
Make 'arch' a variable so we can choose different archs. Like mips, ppc
etc.

Signed-off-by: Benjamin Copeland <ben.copeland@linaro.org>