### PR TITLE
testplans: Remove lkdtm test cases from the test plan

### DIFF
--- a/testplans/lkft-kselftest/kselftests-lkdtm.yaml
+++ b/testplans/lkft-kselftest/kselftests-lkdtm.yaml
@@ -1,1 +1,0 @@
-../../testcases/kselftests-lkdtm.yaml


### PR DESCRIPTION
lkft-kselftest test plan running lkdtm is creating lot of expected
crash logs. Which is getting hard to find the actual crashes.

so lets not run lkdtm test cases from lkft-kselftest plan.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>