### PR TITLE
testplans: drop libgpiod from the lkft-full testplan

### DIFF
--- a/testplans/lkft-full/libgpiod.yaml
+++ b/testplans/lkft-full/libgpiod.yaml
@@ -1,1 +1,0 @@
-../../testcases/libgpiod.yaml


### PR DESCRIPTION
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>