### PR TITLE
qemu: make it possible to use qemu within a docker container

### DIFF
--- a/devices/qemu_arm64
+++ b/devices/qemu_arm64
@@ -1,6 +1,9 @@
 {% set PROJECT = PROJECT|default("") %}
 {% extends PROJECT+"qemu.jinja2" %}
 
+{% if USE_DOCKER is defined and USE_DOCKER == true %}
+{% set DOCKER_QEMU_BINARY = DOCKER_QEMU_BINARY|default("/usr/bin/qemu-system-aarch64") %}
+{% endif %}
 {% set DEPLOY_OS = DEPLOY_OS|default("oe") %}
 {% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("gz") %}
 {% set GS_MACHINE = GS_MACHINE|default("virt,accel=kvm") %}

--- a/devices/qemu_i386
+++ b/devices/qemu_i386
@@ -1,6 +1,9 @@
 {% set PROJECT = PROJECT|default("") %}
 {% extends PROJECT+"qemu.jinja2" %}
 
+{% if USE_DOCKER is defined and USE_DOCKER == true %}
+{% set DOCKER_QEMU_BINARY = DOCKER_QEMU_BINARY|default("/usr/bin/qemu-system-i386") %}
+{% endif %}
 {% set BOOT_OS_PROMPT = BOOT_OS_PROMPT|default("root@intel-core2-32:") %}
 {% set DEPLOY_OS = DEPLOY_OS|default("oe") %}
 {% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("gz") %}

--- a/devices/qemu_x86_64
+++ b/devices/qemu_x86_64
@@ -1,6 +1,9 @@
 {% set PROJECT = PROJECT|default("") %}
 {% extends PROJECT+"qemu.jinja2" %}
 
+{% if USE_DOCKER is defined and USE_DOCKER == true %}
+{% set DOCKER_QEMU_BINARY = DOCKER_QEMU_BINARY|default("/usr/bin/qemu-system-x86_64") %}
+{% endif %}
 {% set BOOT_OS_PROMPT = BOOT_OS_PROMPT|default("root@intel-corei7-64:") %}
 {% set DEPLOY_OS = DEPLOY_OS|default("oe") %}
 {% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("gz") %}

--- a/qemu.jinja2
+++ b/qemu.jinja2
@@ -12,11 +12,19 @@
 {% set TARGET_BOOT_TIMEOUT = TARGET_BOOT_TIMEOUT|default(10) %}
 {% set auto_login = auto_login|default(true) %}
 {% set AUTO_LOGIN_USERNAME = AUTO_LOGIN_USERNAME|default("root") %}
+{% set USE_DOCKER = USE_DOCKER|default(false) %}
+{% if USE_DOCKER is defined and USE_DOCKER == true %}
+{% set DOCKER_QEMU_CONTAINER = DOCKER_QEMU_CONTAINER|default("linaro/lkft-qemu-should-not-used-for-long") %}
+{% set DOCKER_QEMU_VERSION = DOCKER_QEMU_VERSION|default('latest') %}
+{% endif %}
 
 {% block global_settings %}
 {{ super() }}
 {% if guestfs_virtio is defined and guestfs_virtio == true %}
   guestfs_interface: virtio
+{% endif %}
+{% if USE_DOCKER is defined and USE_DOCKER == true %}
+  netdevice: user
 {% endif %}
 {% endblock global_settings %}
 
@@ -153,6 +161,11 @@
 
 {% block boot_target %}
 - boot:
+{% if USE_DOCKER is defined and USE_DOCKER == true %}
+    docker:
+      binary: {{ DOCKER_QEMU_BINARY }}
+      image: {{ DOCKER_QEMU_CONTAINER}}:{{ DOCKER_QEMU_VERSION}}
+{% endif %}
 {% if auto_login == true %}
 {% include "include/boot_target/auto_login.jinja2" %}
 {% block auto_login_commands %}


### PR DESCRIPTION
This makes it easier to test different qemu version. Just pointing to
another DOCKER_QEMU_VERSION, instead of request the lab to update the
qemu-workers.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>