### PR TITLE
lkft: devices: qemu: enable docker

### DIFF
--- a/projects/lkft/devices/qemu_arm64
+++ b/projects/lkft/devices/qemu_arm64
@@ -12,3 +12,4 @@
 {% else %}
 {% set QEMU_CPU_VARIABLES = QEMU_CPU_VARIABLES|default("max") %}
 {% endif %}
+{% set USE_DOCKER = USE_DOCKER|default("true") %}

--- a/projects/lkft/devices/qemu_i386
+++ b/projects/lkft/devices/qemu_i386
@@ -9,3 +9,4 @@
 {% set OVERLAY_MODULES_URL_COMP = OVERLAY_MODULES_URL_COMP|default("xz") %}
 {% set OVERLAY_PERF_URL_FORMAT = OVERLAY_PERF_URL_FORMAT|default("tar") %}
 {% set OVERLAY_PERF_URL_COMP = OVERLAY_PERF_URL_COMP|default("xz") %}
+{% set USE_DOCKER = USE_DOCKER|default("true") %}

--- a/projects/lkft/devices/qemu_x86_64
+++ b/projects/lkft/devices/qemu_x86_64
@@ -9,6 +9,7 @@
 {% set OVERLAY_MODULES_URL_COMP = OVERLAY_MODULES_URL_COMP|default("xz") %}
 {% set OVERLAY_PERF_URL_FORMAT = OVERLAY_PERF_URL_FORMAT|default("tar") %}
 {% set OVERLAY_PERF_URL_COMP = OVERLAY_PERF_URL_COMP|default("xz") %}
+{% set USE_DOCKER = USE_DOCKER|default("true") %}
 
 {% block test_target %}
 {% if enable_tests is defined and enable_tests %}


### PR DESCRIPTION
Use qemu from the docker container instead of qemu from the lab's
qemu-worker.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>