### PR TITLE
projects: lkft: qemu: if only boot

### DIFF
--- a/projects/lkft/qemu.jinja2
+++ b/projects/lkft/qemu.jinja2
@@ -21,6 +21,7 @@
 {% endblock rootfs_extra_args %}
 
 {% block test_target %}
+{% if enable_tests is defined and enable_tests %}
   {{ super() }}
     - from: inline
       repository:
@@ -34,4 +35,5 @@
             - ln -s /tmp /scratch
       name: prep-tmp-disk
       path: inline/prep.yaml
+{% endif %}
 {% endblock test_target %}


### PR DESCRIPTION
Building up a boot test shows this error:

[            main() ] Failed to parse: /lava-test-plans/tmp/qemu_arm64/boot.yaml
[            main() ] while parsing a block mapping
  in "<unicode string>", line 170, column 5:
        auto_login:
        ^ (line: 170)
expected <block end>, but found '-'
  in "<unicode string>", line 196, column 5:
        - from: inline
        ^ (line: 196)

Check if 'enable_tests' is defined and set before adding the inline
snippet.

Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>