### PR TITLE
lkft: devices: rpi4: increase the boot kernel size

### DIFF
--- a/projects/lkft/devices/bcm2711-rpi-4-b
+++ b/projects/lkft/devices/bcm2711-rpi-4-b
@@ -10,6 +10,7 @@
 
 {% block context %}
   {{ super() }}
+  booti_dtb_addr: "0x86000000"
   extra_nfsroot_args: ',vers=3'
   console_device: 'ttyS0'
 {% endblock context %}


### PR DESCRIPTION
Changing the dtb load addr makes the LKFT kernels to fit.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>