### PR TITLE
lkft: devices: juno-r2: increase the boot kernel size

### DIFF
--- a/projects/lkft/devices/juno-r2
+++ b/projects/lkft/devices/juno-r2
@@ -10,6 +10,6 @@
 
 {% block context %}
   {{ super() }}
-  booti_dtb_addr: "0x86000000"
+  booti_dtb_addr: "0x88000000"
   extra_nfsroot_args: ',wsize=65536'
 {% endblock context %}


### PR DESCRIPTION
Bump the dtb load addr so the KASAN kernel fits.

Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>