### PR TITLE
projects: lkft: devices: qemu_arm64: add TCG impdef

### DIFF
--- a/projects/lkft/devices/qemu_arm64
+++ b/projects/lkft/devices/qemu_arm64
@@ -10,5 +10,5 @@
 {% if DEVICE_TYPE == 'qemu_arm' %}
 {% set GS_MACHINE = "virt-2.10,accel=kvm" %}
 {% else %}
-{% set QEMU_CPU_VARIABLES = QEMU_CPU_VARIABLES|default("max") %}
+{% set QEMU_CPU_VARIABLES = QEMU_CPU_VARIABLES|default("max,pauth-impdef=on") %}
 {% endif %}


### PR DESCRIPTION
Add impdef (Implementation Defined) algorithm is enabled or the
architected QARMA algorithm is enabled. By default the impdef algorithm
is disabled, and QARMA is enabled.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>