### PR TITLE
android: add testcase templates for x15 and hikey960 builds

### DIFF
--- a/devices/x15
+++ b/devices/x15
@@ -4,7 +4,7 @@
 {% set DEPLOY_OS = DEPLOY_OS|default("oe") %}
 {% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("gz") %}
 
-{% set boot_method = "u-boot" %}
+{% set boot_method = boot_method|default("u-boot") %}
 {# libhugetlbfs_word_size variable is required for libhugetlbfs.yaml test template #}
 {% set libhuggetlbfs_word_size = 32 %}
 {% set pre_boot_command = false %}

--- a/include/android-boottime-definition.jinja2
+++ b/include/android-boottime-definition.jinja2
@@ -1,0 +1,10 @@
+        - repository: {{ TEST_DEFINITIONS_REPOSITORY }}
+          from: git
+          path: automated/android/boottime/boottime.yaml
+          name: {{ testname }}
+{% if test_operation is defined %}
+          params:
+            ANDROID_VERSION: master
+            OPERATION: {{ test_operation }}
+            COLLECT_NO: {{ test_index }}
+{% endif %}

--- a/include/fastboot.jinja2
+++ b/include/fastboot.jinja2
@@ -20,6 +20,15 @@
 {% set boot_method = boot_method|default("fastboot") %}
 {% set download_postprocess_required = download_postprocess_required|default(true) %}
 
+{% set partition_super = partition_super|default(false) %}
+{% set partition_system = partition_system|default(false) %}
+{% set partition_vendor = partition_vendor|default(false) %}
+{% set partition_vendor_boot = partition_vendor_boot|default(false) %}
+{% set partition_cache = partition_cache|default(false) %}
+{% set partition_vbmeta = partition_vbmeta|default(false) %}
+{% set partition_recovery = partition_recovery|default(false) %}
+{% set partition_userdata = partition_userdata|default(false) %}
+
 {% block global_settings %}
 {{ super() }}
 reboot_to_fastboot: {{ reboot_to_fastboot }}
@@ -140,6 +149,64 @@ reboot_to_fastboot: {{ reboot_to_fastboot }}
 {% endif %}
 {% endif %}
 {% endif %}
+
+{% if partition_super == true %}
+      super:
+        url: {{ SUPER_URL }}
+{% if SUPER_URL_COMP is defined %}
+        compression: {{ SUPER_URL_COMP }}
+{% endif %}
+{% endif %}
+{% if partition_system == true %}
+      system:
+        url: {{ SYSTEM_URL }}
+{% if SYSTEM_URL_COMP is defined %}
+        compression: {{ SYSTEM_URL_COMP }}
+{% endif %}
+{% endif %}
+{% if partition_vendor == true %}
+      vendor:
+        url: {{ VENDOR_URL }}
+{% if VENDOR_URL_COMP is defined %}
+        compression: {{ VENDOR_URL_COMP }}
+{% endif %}
+{% endif %}
+{% if partition_vendor_boot == true %}
+      vendor_boot:
+        url: {{ VENDOR_BOOT_URL }}
+{% if VENDOR_BOOT_URL_COMP is defined %}
+        compression: {{ VENDOR_BOOT_URL_COMP }}
+{% endif %}
+{% endif %}
+{% if partition_cache == true %}
+      cache:
+        url: {{ CACHE_URL }}
+{% if CACHE_URL_COMP is defined %}
+        compression: {{ CACHE_URL_COMP }}
+{% endif %}
+{% endif %}
+{% if partition_vbmeta == true %}
+      vbmeta:
+        url: {{ VBMETA_URL }}
+{% if VBMETA_URL_COMP is defined %}
+        compression: {{ VBMETA_URL_COMP }}
+{% endif %}
+{% endif %}
+{% if partition_recovery == true %}
+      recovery:
+        url: {{ RECOVERY_URL }}
+{% if RECOVERY_URL_COMP is defined %}
+        compression: {{ RECOVERY_URL_COMP }}
+{% endif %}
+{% endif %}
+{% if partition_userdata == true %}
+      userdata:
+        url: {{ RECOVERY_URL }}
+{% if RECOVERY_URL_COMP is defined %}
+        compression: {{ RECOVERY_URL_COMP }}
+{% endif %}
+{% endif %}
+
     os: {{DEPLOY_OS}}
 {% if lxc_project == false and download_postprocess_required == true %}
     postprocess:

--- a/include/fastboot.jinja2
+++ b/include/fastboot.jinja2
@@ -18,6 +18,7 @@
 {% set pre_os_command = pre_os_command|default(true) %}
 {% set auto_login = auto_login|default(true) %}
 {% set boot_method = boot_method|default("fastboot") %}
+{% set download_postprocess_required = download_postprocess_required|default(true) %}
 
 {% block global_settings %}
 {{ super() }}
@@ -140,7 +141,7 @@ reboot_to_fastboot: {{ reboot_to_fastboot }}
 {% endif %}
 {% endif %}
     os: {{DEPLOY_OS}}
-{% if lxc_project == false %}
+{% if lxc_project == false and download_postprocess_required == true %}
     postprocess:
       docker:
         image: {{DOCKER_IMAGE}}

--- a/include/test_target.jinja2
+++ b/include/test_target.jinja2
@@ -1,5 +1,11 @@
+{% set use_docker_image_for_test_target = use_docker_image_for_test_target|default(false) %}
+
 {% if enable_tests is defined and enable_tests %}
 - test:
+{% if use_docker_image_for_test_target == true %}
+    docker:
+      image: {{ DOCKER_IMAGE }}
+{% endif %}
 {% if lxc_project == true %}
     namespace: target
 {% endif %}

--- a/projects/lkft-android/boot.yaml
+++ b/projects/lkft-android/boot.yaml
@@ -1,0 +1,1 @@
+../../testcases/android-boot.yaml

--- a/projects/lkft-android/devices/x15
+++ b/projects/lkft-android/devices/x15
@@ -1,0 +1,25 @@
+{% extends "devices/x15" %}
+
+{% set TAGS = TAGS|default(["hdmi-dongle"]) %}
+
+{% set auto_login = auto_login|default(false) %}
+{% set boot_method = boot_method |default("fastboot") %}
+{% set BOOT_OS_PROMPT = [" :/"] %}
+
+{% set partition_boot_a = partition_boot_a|default(true) %}
+{% set partition_boot_b = partition_boot_b|default(true) %}
+{% set partition_vbmeta = partition_vbmeta|default(true) %} {# for the deploy download action#}
+{% set partition_vbmeta_a = partition_vbmeta_a|default(true) %}
+{% set partition_vbmeta_b = partition_vbmeta_b|default(true) %}
+{% set partition_super = partition_super|default(true) %}
+{% set partition_userdata = partition_userdata|default(true) %}
+{% set partition_recovery = partition_recovery|default(true) %}
+
+{# override the boot_commands block defined in "devices/x15" #}
+{% block boot_commands %}
+{% endblock boot_commands %}
+
+{# override the test_target block defined in "devices/x15" #}
+{% block test_target %}
+{% include "include/test_target.jinja2" %}
+{% endblock test_target %}

--- a/projects/lkft-android/fastboot.jinja2
+++ b/projects/lkft-android/fastboot.jinja2
@@ -1,0 +1,119 @@
+{% extends "include/fastboot.jinja2" %}
+
+{% set deploy_download_timeout = deploy_download_timeout|default(15) %}
+{% set deploy_fastboot_timeout = deploy_fastboot_timeout|default(10) %}
+{% set pre_boot_timeout = pre_boot_timeout|default(0) %}
+{% set post_boot_timeout = post_boot_timeout|default(10) %}
+
+{# target_deploy_timeout is used to calculate the job_timeout defined in the root master.jinja2 file #}
+{# for android the variables of download_timeout, deploy_timeout, between_deploy_boot_timeout are used in the file devices/android/device-base#}
+{# common_tests_after_boot_timeout needs to be defined when there are common actions defined after the boot, but before the real tests started#}
+{% set target_deploy_timeout = deploy_download_timeout + deploy_fastboot_timeout + pre_boot_timeout + post_boot_timeout %}
+
+{% set rootfs = rootfs|default(false) %}
+{% set download_postprocess_required = download_postprocess_required|default(false) %}
+{% set DEPLOY_TARGET = DEPLOY_TARGET|default("downloads") %}
+
+{% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("ptable-linux-8g.img") %}
+{% set DOCKER_BOOT_FILE = DOCKER_BOOT_FILE|default("boot.img") %}
+{% set DOCKER_VBMETA_FILE = DOCKER_VBMETA_FILE|default("vbmeta.img") %}
+{% set DOCKER_SUPER_FILE = DOCKER_SUPER_FILE|default("super.img") %}
+{% set DOCKER_SYSTEM_FILE = DOCKER_SYSTEM_FILE|default("system.img") %}
+{% set DOCKER_VENDOR_FILE = DOCKER_VENDOR_FILE|default("vendor.img") %}
+{% set DOCKER_VENDOR_BOOT_FILE = DOCKER_VENDOR_BOOT_FILE|default("vendor_boot.img") %}
+{% set DOCKER_CACHE_FILE = DOCKER_CACHE_FILE|default("cache.img") %}
+{% set DOCKER_METADATA_FILE = DOCKER_METADATA_FILE|default("metadata.img") %}
+{% set DOCKER_RECOVERY_FILE = DOCKER_RECOVERY_FILE|default("recovery.img") %}
+{% set DOCKER_USERDATA_FILE = DOCKER_USERDATA_FILE|default("userdata.img") %}
+
+{#################### job definitions ##########################}
+
+{% block visibility %}
+  group:
+    - {{ TEST_LAVA_JOB_GROUP }}
+{% endblock visibility %}
+
+{% block settings %}
+secrets:
+  ARTIFACTORIAL_TOKEN: "{{ ARTIFACTORIAL_TOKEN }}"
+{% endblock settings %}
+
+{% block metadata %}
+{% include PROJECT+"include/metadata.jinja2" %}
+{% block job_specific_metadata %}
+{% endblock job_specific_metadata %}
+{% endblock metadata %}
+
+{% block deploy_target %}
+{{ super() }}
+
+{% block deploy_fastboot %}
+- deploy:
+    timeout:
+      minutes: {{ deploy_fastboot_timeout }}
+    to: fastboot
+    docker:
+      image: {{ DOCKER_IMAGE }}
+    images:
+{% if ptable == true %}
+      {{ PTABLE_LABEL }}:
+        url: downloads://{{ DOCKER_PTABLE_FILE }}
+{% endif %}
+{# only deploy to the boot partition when A/B partition not supported #}
+{% if boot == true and partition_boot_a == false %}
+      boot:
+        url: downloads://{{ DOCKER_BOOT_FILE }}
+{% endif %}
+{% if partition_boot_a == true %}
+      boot_a:
+        url: downloads://{{ DOCKER_BOOT_FILE }}
+{% endif %}
+{% if partition_boot_b == true %}
+      boot_b:
+        url: downloads://{{ DOCKER_BOOT_FILE }}
+{% endif %}
+{% if partition_super == true %}
+      super:
+        url: downloads://{{ DOCKER_SUPER_FILE }}
+{% endif %}
+{% if partition_system == true %}
+      system:
+        url: downloads://{{ DOCKER_SYSTEM_FILE }}
+{% endif %}
+{% if partition_vendor == true %}
+      vendor:
+        url: downloads://{{ DOCKER_VENDOR_FILE }}
+{% endif %}
+{% if partition_vendor_boot == true %}
+      vendor_boot:
+        url: downloads://{{ DOCKER_VENDOR_BOOT_FILE }}
+{% endif %}
+{% if partition_cache == true %}
+      cache:
+        url: downloads://{{ DOCKER_CACHE_FILE }}
+{% endif %}
+{% if partition_vbmeta_a == true %}
+      vbmeta_a:
+        url: downloads://{{ DOCKER_VBMETA_FILE }}
+{% endif %}
+{% if partition_vbmeta_b == true %}
+      vbmeta_b:
+        url: downloads://{{ DOCKER_VBMETA_FILE }}
+{% endif %}
+{% if partition_recovery == true %}
+      recovery:
+        url: downloads://{{ DOCKER_RECOVERY_FILE }}
+{% endif %}
+{% if partition_userdata == true %}
+      userdata:
+        url: downloads://{{ DOCKER_USERDATA_FILE }}
+{% endif %}
+{% endblock deploy_fastboot %}
+{% endblock deploy_target %}
+
+{% block post_boot_command %}
+{% with test_timeout=post_boot_timeout %}
+{% include "include/test_target.jinja2" %}
+{% endwith %}
+{% include PROJECT+"include/lkft-common-actions.jinja2" %}
+{% endblock post_boot_command %}

--- a/projects/lkft-android/include/lkft-common-actions.jinja2
+++ b/projects/lkft-android/include/lkft-common-actions.jinja2
@@ -1,0 +1,15 @@
+    - from: inline
+      path: android-boot.yaml
+      name: android-boot
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: android-boot
+          description: "android-boot"
+        run:
+          steps:
+            - lava-test-case "android-boot-sleep-30secs" --shell sleep 30
+            - lava-test-case "android-boot-lsusb-v" --shell lsusb -v
+            - lava-test-case "android-boot-boot-completed" --shell "while ! adb shell getprop sys.boot_completed|grep 1; do sleep 2; done"
+            - lava-test-case "android-boot-set-power-stayon" --shell adb shell su 0 svc power stayon true
+            - lava-test-case "android-boot-screencap" --shell adb shell screencap -p /data/local/tmp/screencap.png

--- a/projects/lkft-android/include/metadata.jinja2
+++ b/projects/lkft-android/include/metadata.jinja2
@@ -1,0 +1,22 @@
+  android.build: "{{ BUILD_NUMBER }}"
+  android.name: "{{ JOB_NAME }}"
+  android.url: "{{ REFERENCE_BUILD_URL }}"
+  android.version: "{{ ANDROID_VERSION }}"
+{% if ANDROID_VENDOR_FINGERPRINT is defined %}
+  android.build.vendor.fingerprint: "{{ ANDROID_VENDOR_FINGERPRINT }}"
+{% endif %}
+{% if ANDROID_GSI_FINGERPRINT is defined %}
+  android.build.gsi.url: "{{ ANDROID_GSI_URL }}"
+  android.build.gsi.fingerprint: "{{ ANDROID_GSI_FINGERPRINT }}"
+{% endif %}
+{% if TUXSUITE_DOWNLOAD_URL is defined %}
+  tuxsuite.download.url: "{{ TUXSUITE_DOWNLOAD_URL }}"
+{% endif %}
+  lkft.build.config: "{{ LKFT_BUILD_CONFIG }}"
+  git branch: "{{ KERNEL_BRANCH }}"
+  git repo: "{{ KERNEL_REPO }}"
+  git commit: "{{ KERNEL_COMMIT }}"
+  git describe: "{{ KERNEL_DESCRIBE }}"
+  build-url: "{{ BUILD_URL }}"
+  toolchain: "{{ TEST_METADATA_TOOLCHAIN }}"
+  series: lkft

--- a/projects/lkft-android/variables-android.ini
+++ b/projects/lkft-android/variables-android.ini
@@ -1,0 +1,30 @@
+# variables must be defined in the build config
+TEST_DEVICE_TYPE=device-type-unknown
+REFERENCE_BUILD_URL=reference-build-url-unknown
+ANDROID_VERSION=android-version-unknown
+KERNEL_BRANCH=kernel-branch-unknown
+KERNEL_REPO=kernel-repo-unknown
+TEST_CTS_URL=test-cts-url-unknown
+TEST_VTS_URL=test-vts-url-unknow
+# vairiable might be defined in the build config for not
+# if not defined, need to give the default value
+LAVA_JOB_PRIORITY=lava-job-priority-unknown
+TEST_LAVA_JOB_GROUP=test-lava-job-group-unknown
+# variables would be generated during the build
+BUILD_URL=buid-job-url-unknow
+BUILD_NUMBER=build-job-number-unknown
+JOB_NAME=build-job-name-unknown
+DOWNLOAD_URL=download-url-unknow
+# variables need to be set before run the submit_for_testing.py
+LKFT_BUILD_CONFIG=lkft-build-config-unknown
+KERNEL_COMMIT=kernel-commit-unknown
+KERNEL_DESCRIBE=kernel-describe-unknown
+TEST_METADATA_TOOLCHAIN=toolchain-unknow
+TEST_CTS_VERSION=cts-version-unknown
+TEST_VTS_VERSION=vts-version-unknown
+# screct information for tokens and passwords
+# that would be defined as environment variables
+# by the CI system
+ARTIFACTORIAL_TOKEN=ARTIFACTORIAL_TOKEN
+AP_KEY=AP_KEY
+AP_SSID=AP_SSID

--- a/testcases/android-boot.yaml
+++ b/testcases/android-boot.yaml
@@ -1,0 +1,10 @@
+{% extends "testcases/master/template-android.jinja2" %}
+
+{% set test_timeout = 30 %}
+{% set test_name = "boot" %}
+
+{% block test_target_definitions %}
+{% with testname="boot-test" %}
+{% include "include/android-boottime-definition.jinja2" %}
+{% endwith %}
+{% endblock test_target_definitions %}

--- a/testcases/master/template-android.jinja2
+++ b/testcases/master/template-android.jinja2
@@ -1,0 +1,17 @@
+{% extends "testcases/master/template-master.jinja2" %}
+
+{% set OS_INFO = OS_INFO|default("android") %}
+{% set DEPLOY_OS = DEPLOY_OS|default("android") %}
+
+{# urls #}
+{% set DOCKER_IMAGE = DOCKER_IMAGE|default("yongqinliu/linaro-android-docker:0.1") %}
+{% set use_docker_image_for_test_target = use_docker_image_for_test_target|default(true) %}
+
+{# variables needs to be converted to be used by the root master.jinja2 #}
+{% set LAVA_JOB_PRIORITY = LAVA_JOB_PRIORITY|default("medium") %}
+
+{########## LAVA JOB DEFINITION ##############}
+{% block test_target %}
+    {{ super() }}
+    {% block test_target_definitions %}{% endblock test_target_definitions %}
+{% endblock test_target %}


### PR DESCRIPTION
with the docker method used for lava jobs.
needs to specify the --testplan-path to testcases/android,
and --testplan-device-path to devices/android/,
for the submit_for_testing.py script to be run

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>