### PR TITLE
testcases: add vdso test

### DIFF
--- a/.github/workflows/test-plans-pipeline.yml
+++ b/.github/workflows/test-plans-pipeline.yml
@@ -56,6 +56,7 @@ jobs:
          python3 submit_for_testing.py --variables projects/lkft/variables.yaml --device-type thunderx --dry-run --test-plan lkft-full --test-lava-validity --testplan-device-path projects/lkft/devices
          python3 submit_for_testing.py --variables projects/lkft/variables.yaml --device-type bcm2711-rpi-4-b --dry-run --test-plan lkft-full --test-lava-validity
          python3 submit_for_testing.py --variables projects/lkft/variables.yaml --device-type bcm2711-rpi-4-b --dry-run --test-plan lkft-full --test-lava-validity --testplan-device-path projects/lkft/devices
+         python3 submit_for_testing.py --variables projects/lkft/variables.yaml --device-type juno-r2 --dry-run --test-case vdso.yaml --test-lava-validity
          python3 submit_for_testing.py --variables projects/lt-qcom/variables.yaml --device-type dragonboard-410c --dry-run --test-plan lt-qcom/kernel --test-lava-validity --testplan-device-path projects/lt-qcom/devices
          python3 submit_for_testing.py --variables projects/lt-qcom/variables.yaml --device-type dragonboard-820c --dry-run --test-plan lt-qcom/kernel --test-lava-validity --testplan-device-path projects/lt-qcom/devices
          python3 submit_for_testing.py --variables projects/lt-qcom/variables.yaml --device-type qcs404-evb-1k --dry-run --test-plan lt-qcom/kernel --test-lava-validity --testplan-device-path projects/lt-qcom/devices

--- a/testcases/vdso.yaml
+++ b/testcases/vdso.yaml
@@ -1,0 +1,12 @@
+{% extends "testcases/master/template-test.jinja2" %}
+
+{% set test_name = test_name | default("vdso") %}
+{% set test_path_file = 'automated/linux/vdsotest/vdsotest.yaml' %}
+{% set test_timeout = 15 %}
+
+{% block test_target %}
+  {{ super() }}
+      parameters:
+        SKIP_INSTALL: 'true'
+        VDSOTESTALL: 'all'
+{% endblock test_target %}


### PR DESCRIPTION
vdsotest is a utility for testing and benchmarking a Linux VDSO. The
"vDSO" (virtual dynamic shared object) is a small shared library that
the kernel automatically maps into the address space of all user-space
applications.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>