### PR TITLE
lkft-kselftest: Remove kvm from default kselftest plan

### DIFF
--- a/testplans/lkft-kselftest/kselftests-kvm.yaml
+++ b/testplans/lkft-kselftest/kselftests-kvm.yaml
@@ -1,1 +1,0 @@
-../../testcases/kselftests-kvm.yaml


### PR DESCRIPTION
kselftest kvm should not be run on 32-bit architectures and qemu's
so remove it from default test plan and add only to specific device.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>