### PR TITLE
master.jinja2: drop the device_type block

### DIFF
--- a/devices/bcm2711-rpi-4-b
+++ b/devices/bcm2711-rpi-4-b
@@ -13,8 +13,6 @@
   arch: arm64
 {% endblock context %}
 
-{% block device_type %}bcm2711-rpi-4-b{% endblock %}
-
 {% block boot_target %}
 {{ super() }}
 {% endblock boot_target %}

--- a/devices/dragonboard-410c
+++ b/devices/dragonboard-410c
@@ -6,5 +6,3 @@
 {% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("gz") %}
 
 {% set rootfs_label = 'rootfs' %}
-
-{% block device_type %}dragonboard-410c{% endblock %}

--- a/devices/dragonboard-820c
+++ b/devices/dragonboard-820c
@@ -6,5 +6,3 @@
 {% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("gz") %}
 
 {% set rootfs_label = 'rootfs' %}
-
-{% block device_type %}dragonboard-820c{% endblock %}

--- a/devices/dragonboard-845c
+++ b/devices/dragonboard-845c
@@ -9,5 +9,3 @@
 {% set ptable = true %}
 {% set rootfs_label = 'rootfs' %}
 {% set reboot_reset = true %}
-
-{% block device_type %}dragonboard-845c{% endblock %}

--- a/devices/hi6220-hikey-r2
+++ b/devices/hi6220-hikey-r2
@@ -15,8 +15,6 @@
 {% set rootfs = true %}
 {% set rootfs_label = rootfs_label|default("system") %}
 
-{% block device_type %}hi6220-hikey-r2{% endblock %}
-
 {% block auto_login_commands %}
       login_commands:
         # Become super user to run tests

--- a/devices/hi960-hikey
+++ b/devices/hi960-hikey
@@ -12,8 +12,6 @@
 {% set rootfs = true %}
 {% set rootfs_label = 'system' %}
 
-{% block device_type %}hi960-hikey{% endblock %}
-
 {% block boot_commands %}
     commands: installed
 {% endblock boot_commands %}

--- a/devices/juno
+++ b/devices/juno
@@ -11,8 +11,6 @@
 {% block context %}
 {% endblock context %}
 
-{% block device_type %}juno{% endblock %}
-
 {% block boot_target %}
 {{ super() }}
 {% endblock boot_target %}

--- a/devices/juno-r2
+++ b/devices/juno-r2
@@ -13,8 +13,6 @@
   bootloader_prompt: juno#
 {% endblock context %}
 
-{% block device_type %}juno-r2{% endblock %}
-
 {% block boot_target %}
 {{ super() }}
 {% endblock boot_target %}

--- a/devices/nxp-ls2088
+++ b/devices/nxp-ls2088
@@ -13,8 +13,6 @@
   arch: arm64
 {% endblock context %}
 
-{% block device_type %}nxp-ls2088{% endblock %}
-
 {% block boot_target %}
 {{ super() }}
 {% endblock boot_target %}

--- a/devices/qcs404-evb-1k
+++ b/devices/qcs404-evb-1k
@@ -8,5 +8,3 @@
 {% set pre_power_command = false %}
 {% set pre_os_command = false %}
 {% set rootfs_label = 'userdata' %}
-
-{% block device_type %}qcs404-evb-1k{% endblock %}

--- a/devices/qcs404-evb-4k
+++ b/devices/qcs404-evb-4k
@@ -8,5 +8,3 @@
 {% set pre_power_command = false %}
 {% set pre_os_command = false %}
 {% set rootfs_label = 'userdata' %}
-
-{% block device_type %}qcs404-evb-4k{% endblock %}

--- a/devices/qemu_arm64
+++ b/devices/qemu_arm64
@@ -9,6 +9,8 @@
 {% set GS_MACHINE = GS_MACHINE|default("virt,accel=kvm") %}
 {% set QEMU_CPU_VARIABLES = QEMU_CPU_VARIABLES|default("host") %}
 
+{% set lava_device_type = lava_device_type|default("qemu-arm") %}
+
 {% block global_settings %}
 {{ super() }}
   arch: arm64
@@ -17,8 +19,6 @@
   cpu: {{ QEMU_CPU_VARIABLES }}{% if DEVICE_TYPE == 'qemu_arm' %},aarch64=off{% endif %}
   guestfs_size: {{ guestfs_size|default(512) }}
 {% endblock global_settings %}
-
-{% block device_type %}qemu-arm{% endblock %}
 
 {% block rootfs_extra_args %}
         {{ super() }}

--- a/devices/qemu_i386
+++ b/devices/qemu_i386
@@ -11,13 +11,13 @@
 {# libhugetlbfs_word_size variable is required for libhugetlbfs.yaml test template #}
 {% set libhuggetlbfs_word_size = 32 %}
 
+{% set lava_device_type = lava_device_type|default("qemu") %}
+
 {% block global_settings %}
 {{ super() }}
   arch: i386
   guestfs_size: {{ guestfs_size|default(512) }}
 {% endblock global_settings %}
-
-{% block device_type %}qemu{% endblock %}
 
 {% block boot_extra_args %}
         image_arg: -kernel {kernel} --append "root=/dev/sda  rootwait console=ttyS0,115200"

--- a/devices/qemu_x86_64
+++ b/devices/qemu_x86_64
@@ -8,13 +8,13 @@
 {% set DEPLOY_OS = DEPLOY_OS|default("oe") %}
 {% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("gz") %}
 
+{% set lava_device_type = lava_device_type|default("qemu") %}
+
 {% block global_settings %}
 {{ super() }}
   arch: amd64
   guestfs_size: {{ guestfs_size|default(512) }}
 {% endblock global_settings %}
-
-{% block device_type %}qemu{% endblock %}
 
 {% block boot_extra_args %}
         image_arg: -kernel {kernel} --append "root=/dev/sda  rootwait console=ttyS0,115200"

--- a/devices/rzn1d
+++ b/devices/rzn1d
@@ -12,8 +12,6 @@
 {% set TARGET_BOOT_TIMEOUT = 10 %}
 {% set target_deploy_timeout = 5 %}
 
-{% block device_type %}rzn1d{% endblock %}
-
 {% block kernel_extra_args %}
       type: uimage
 {% endblock kernel_extra_args %}

--- a/devices/sdm845-mtp
+++ b/devices/sdm845-mtp
@@ -8,5 +8,3 @@
 {% set pre_power_command = false %}
 {% set pre_os_command = false %}
 {% set rootfs_label = 'userdata' %}
-
-{% block device_type %}sdm845-mtp{% endblock %}

--- a/devices/sm8150-mtp
+++ b/devices/sm8150-mtp
@@ -8,5 +8,3 @@
 {% set pre_power_command = false %}
 {% set pre_os_command = false %}
 {% set rootfs_label = 'userdata' %}
-
-{% block device_type %}sm8150-mtp{% endblock %}

--- a/devices/sm8250-mtp
+++ b/devices/sm8250-mtp
@@ -8,5 +8,3 @@
 {% set pre_power_command = false %}
 {% set pre_os_command = false %}
 {% set rootfs_label = 'userdata' %}
-
-{% block device_type %}sm8250-mtp{% endblock %}

--- a/devices/sm8350-mtp
+++ b/devices/sm8350-mtp
@@ -8,5 +8,3 @@
 {% set pre_power_command = false %}
 {% set pre_os_command = false %}
 {% set rootfs_label = 'userdata' %}
-
-{% block device_type %}sm8350-mtp{% endblock %}

--- a/devices/soca9
+++ b/devices/soca9
@@ -12,8 +12,6 @@
 {% set run_tftp_commands = true %}
 {% set target_deploy_timeout = 5 %}
 
-{% block device_type %}soca9{% endblock %}
-
 {% block deploy_target %}
 - deploy:
     timeout:

--- a/devices/stm32mp157c-dk2
+++ b/devices/stm32mp157c-dk2
@@ -14,5 +14,3 @@
 {% set rootfs = rootfs|default(false) %}
 {% set boot_method = boot_method|default("minimal") %}
 {% set auto_login = auto_login|default(false) %}
-
-{% block device_type %}stm32mp157c-dk2{% endblock %}

--- a/devices/synquacer
+++ b/devices/synquacer
@@ -10,8 +10,6 @@
   test_character_delay: 10
 {% endblock context %}
 
-{% block device_type %}synquacer{% endblock %}
-
 {% block boot_commands %}
     commands: nfs
     parameters:

--- a/devices/thunderx
+++ b/devices/thunderx
@@ -16,8 +16,6 @@
   test_character_delay: 10
 {% endblock context %}
 
-{% block device_type %}thunderx{% endblock %}
-
 {% block boot_commands %}
     commands: nfs
     parameters:

--- a/devices/x15
+++ b/devices/x15
@@ -13,8 +13,6 @@
 {% set reboot_to_fastboot = reboot_to_fastboot|default("true") %}
 {% set rootfs_label = "super" %}
 
-{% block device_type %}x15{% endblock %}
-
 {% block boot_commands %}
     commands:
     - setenv fdtfile am57xx-beagle-x15.dtb

--- a/devices/x15-bl
+++ b/devices/x15-bl
@@ -8,8 +8,6 @@
 {% set pre_os_command = false %}
 {% set rootfs_label = "userdata" %}
 
-{% block device_type %}x15-bl{% endblock %}
-
 {% block boot_commands %}
 {% if boot_method == "u-boot" %}
     commands: {{ BOOT_COMMANDS|default("ramdisk") }}

--- a/devices/x86
+++ b/devices/x86
@@ -10,11 +10,13 @@
 {% set rootfs_label="nfsrootfs" %}
 {% set use_context = true %}
 
+{% if DEVICE_TYPE == 'i386' %}
+{% set lava_device_type = lava_device_type|default("x86") %}
+{% endif %}
+
 {% block context %}
   test_character_delay: 10
 {% endblock context %}
-
-{% block device_type %}x86{% endblock %}
 
 {% block boot_commands %}
     commands: nfs

--- a/master.jinja2
+++ b/master.jinja2
@@ -20,6 +20,8 @@
 
 {% set enable_tests = enable_tests|default(true) %}
 
+{% set lava_device_type = lava_device_type|default(device_type) %}
+
 {% block global_settings %}
 timeouts:
   job:
@@ -42,7 +44,7 @@ context:
 
 
 {% set LAVA_JOB_VISIBILITY = LAVA_JOB_VISIBILITY|default("public") %}
-device_type: {% block device_type %}{% endblock %}
+device_type: {{ lava_device_type }}
 job_name: {% block job_name %}{% endblock %}
 priority: {% block priority %}{{LAVA_JOB_PRIORITY}}{% endblock priority %}
 visibility: {% block visibility %}{{LAVA_JOB_VISIBILITY}}{% endblock visibility %}


### PR DESCRIPTION
use the device_type variable to define the device type in master.jinja2.
This needs the device file names here to be the same as the device type
defined in the lava instances.

Note:
    1. devices/hi6220-hikey is changed to devices/hi6220-hikey-r2
    2. defined lava_device_type for corner cases like the qemu devices
       they need to set the lava_device_type correctly in their own device files
    3. the DEVICE_TYPE should be changed to use device_type instead,
       but it could be done in a separate change

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>