### PR TITLE
drop the 'DEVICE_TYPE' variable

### DIFF
--- a/devices/qemu_arm64
+++ b/devices/qemu_arm64
@@ -14,7 +14,7 @@
   arch: arm64
   netdevice: tap
   machine: {{ GS_MACHINE }}
-  cpu: {{ QEMU_CPU_VARIABLES }}{% if DEVICE_TYPE == 'qemu_arm' %},aarch64=off{% endif %}
+  cpu: {{ QEMU_CPU_VARIABLES }}{% if device_type == 'qemu_arm' %},aarch64=off{% endif %}
   guestfs_size: {{ guestfs_size|default(512) }}
 {% endblock global_settings %}
 

--- a/projects/armnn/variables.yaml
+++ b/projects/armnn/variables.yaml
@@ -3,7 +3,6 @@
 "KERNEL_ARCH_ARTIFACTS_PUB_DEST": "artifact-url"
 "BOOT_URL": "boot-url"
 "SYSTEM_URL": "system-url"
-"DEVICE_TYPE": "device-type"
 "BUILD_NUMBER": "123"
 "LAVA_JOB_PRIORITY": "99"
 "ROOTFS_URL": "variable-value"

--- a/projects/lkft/devices/qemu_arm64
+++ b/projects/lkft/devices/qemu_arm64
@@ -7,7 +7,7 @@
 {% set OVERLAY_MODULES_URL_COMP = OVERLAY_MODULES_URL_COMP|default("xz") %}
 {% set OVERLAY_PERF_URL_FORMAT = OVERLAY_PERF_URL_FORMAT|default("tar") %}
 {% set OVERLAY_PERF_URL_COMP = OVERLAY_PERF_URL_COMP|default("xz") %}
-{% if DEVICE_TYPE == 'qemu_arm' %}
+{% if device_type == 'qemu_arm' %}
 {% set GS_MACHINE = "virt-2.10,accel=kvm" %}
 {% else %}
 {% set QEMU_CPU_VARIABLES = QEMU_CPU_VARIABLES|default("max,pauth-impdef=on") %}

--- a/projects/lkft/fastboot.jinja2
+++ b/projects/lkft/fastboot.jinja2
@@ -15,7 +15,7 @@
 {{ super() }}
 {% if DEPLOY_TARGET == "downloads" %}
         steps:
-        - /kir/lava/board_setup.sh {{DEVICE_TYPE}}
+        - /kir/lava/board_setup.sh {{device_type}}
 
 - deploy:
     timeout:

--- a/projects/lkft/qemu.jinja2
+++ b/projects/lkft/qemu.jinja2
@@ -4,7 +4,7 @@
 {% include PROJECT+"include/lkft-metadata.jinja2" %}
 {% endblock metadata %}
 
-{% if DEVICE_TYPE == 'qemu_arm' %}
+{% if device_type == 'qemu_arm' %}
 {# libhugetlbfs_word_size variable is required for libhugetlbfs.yaml test template #}
 {% set libhuggetlbfs_word_size = 32 %}
 {% set AUTO_LOGIN_PROMPT = AUTO_LOGIN_PROMPT|default("am57xx-evm login:") %}

--- a/projects/lkft/variables.ini
+++ b/projects/lkft/variables.ini
@@ -10,7 +10,6 @@ BUILD_URL=build-url
 KERNEL_ARCH_ARTIFACTS_PUB_DEST=artifact-url
 BOOT_URL=boot-url
 SYSTEM_URL=system-url
-DEVICE_TYPE=device-type
 SKIPGEN_KERNEL_VERSION=skipgen-kernel-version
 BUILD_NUMBER=123
 LAVA_JOB_PRIORITY=99

--- a/projects/lkft/variables.yaml
+++ b/projects/lkft/variables.yaml
@@ -10,7 +10,6 @@
 "KERNEL_ARCH_ARTIFACTS_PUB_DEST": "artifact-url"
 "BOOT_URL": "boot-url"
 "SYSTEM_URL": "system-url"
-"DEVICE_TYPE": "device-type"
 "SKIPGEN_KERNEL_VERSION": "skipgen-kernel-version"
 "BUILD_NUMBER": "123"
 "LAVA_JOB_PRIORITY": "99"

--- a/testcases/master/template-kselftest.yaml.jinja2
+++ b/testcases/master/template-kselftest.yaml.jinja2
@@ -44,7 +44,7 @@
         TST_CMDFILES: '{{testname}}'
         KSELFTEST_PATH: {{KSELFTEST_PATH}}
         SKIPFILE: skipfile-lkft.yaml
-        BOARD: '{{ DEVICE_TYPE }}'
+        BOARD: '{{ device_type }}'
         BRANCH: '{{ SKIPGEN_KERNEL_VERSION|default('default') }}'
         ENVIRONMENT: '{{ ENVIRONMENT|default("production") }}'
 {% endfor %}

--- a/testcases/master/template-kvm-unit-tests.yaml.jinja2
+++ b/testcases/master/template-kvm-unit-tests.yaml.jinja2
@@ -17,6 +17,6 @@
   {{ super() }}
       parameters:
         SKIP_INSTALL: 'true'
-        SMP: {% if DEVICE_TYPE == "juno-r2" %}'false'{% else %}'true'{% endif %}
+        SMP: {% if device_type == "juno-r2" %}'false'{% else %}'true'{% endif %}
         GIT_REF: "{{KVM_UNIT_TESTS_REVISION | default('a3d5d6b9333e10898852b96311c3d3db0baf5a4e')}}"
 {% endblock test_target %}

--- a/testcases/master/template-ltp.yaml.jinja2
+++ b/testcases/master/template-ltp.yaml.jinja2
@@ -27,7 +27,7 @@
         SKIP_INSTALL: 'true'
         TST_CMDFILES: '{{testname}}'
         SKIPFILE: skipfile-lkft.yaml
-        BOARD: '{{ DEVICE_TYPE }}'
+        BOARD: '{{ device_type }}'
         BRANCH: '{{ SKIPGEN_KERNEL_VERSION|default('default') }}'
         ENVIRONMENT: '{{ ENVIRONMENT|default('production') }}'
         TIMEOUT_MULTIPLIER: '{{ TIMEOUT_MULTIPLIER|default('3') }}'

--- a/variables.ini
+++ b/variables.ini
@@ -10,7 +10,6 @@ BUILD_URL=build-url
 KERNEL_ARCH_ARTIFACTS_PUB_DEST=artifact-url
 BOOT_URL=boot-url
 SYSTEM_URL=system-url
-DEVICE_TYPE=device-type
 SKIPGEN_KERNEL_VERSION=skipgen-kernel-version
 BUILD_NUMBER=123
 LAVA_JOB_PRIORITY=99

--- a/variables.yaml
+++ b/variables.yaml
@@ -10,7 +10,6 @@
 "KERNEL_ARCH_ARTIFACTS_PUB_DEST": "artifact-url"
 "BOOT_URL": "boot-url"
 "SYSTEM_URL": "system-url"
-"DEVICE_TYPE": "device-type"
 "SKIPGEN_KERNEL_VERSION": "skipgen-kernel-version"
 "BUILD_NUMBER": "123"
 "LAVA_JOB_PRIORITY": "99"


### PR DESCRIPTION
Drop the 'DEVICE_TYPE' variable in favor the 'device_type' variable.

Reported-by: Yongqin Liu <yongqin.liu@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>