### PR TITLE
job_timeout calculation: fix issues on the lxc actions and deploy download action

### DIFF
--- a/include/fastboot.jinja2
+++ b/include/fastboot.jinja2
@@ -20,11 +20,16 @@
 {% set boot_method = boot_method|default("fastboot") %}
 {% set deploy_download_timeout = deploy_download_timeout|default(target_deploy_timeout) %}
 
+{% set pre_boot_timeout = pre_boot_timeout|default(0) %}
+{% set post_boot_timeout = post_boot_timeout|default(0) %}
+
 {% DEPLOY_TARGET == "downloads" %}
 {% set calc_target_deploy_timeout = deploy_download_timeout + target_deploy_timeout %}
 {% else %}
 {% set calc_target_deploy_timeout = target_deploy_timeout %}
 {% endif %}
+
+{% set calc_boot_timeout = pre_boot_timeout + TARGET_BOOT_TIMEOUT + post_boot_timeout %}
 
 {% block global_settings %}
 {{ super() }}

--- a/include/fastboot.jinja2
+++ b/include/fastboot.jinja2
@@ -18,6 +18,13 @@
 {% set pre_os_command = pre_os_command|default(true) %}
 {% set auto_login = auto_login|default(true) %}
 {% set boot_method = boot_method|default("fastboot") %}
+{% set deploy_download_timeout = deploy_download_timeout|default(target_deploy_timeout) %}
+
+{% DEPLOY_TARGET == "downloads" %}
+{% set calc_target_deploy_timeout = deploy_download_timeout + target_deploy_timeout %}
+{% else %}
+{% set calc_target_deploy_timeout = target_deploy_timeout %}
+{% endif %}
 
 {% block global_settings %}
 {{ super() }}
@@ -35,7 +42,11 @@ reboot_to_fastboot: {{ reboot_to_fastboot }}
     namespace: target
 {% endif %}
     timeout:
+{% if DEPLOY_TARGET == "downloads" %}
+      minutes: {{ deploy_download_timeout }}
+{% else %}
       minutes: {{ target_deploy_timeout }}
+{% endif %}
     to: {{ DEPLOY_TARGET }}
     images:
 {% if rootfs == true %}

--- a/master.jinja2
+++ b/master.jinja2
@@ -9,7 +9,11 @@
 {% set test_timeout = test_timeout|default(60) %}
 {% set TEST_DEFINITIONS_REPOSITORY = TEST_DEFINITIONS_REPOSITORY|default("https://github.com/Linaro/test-definitions.git") %}
 
+{% if lxc_project == true %}
 {% set job_timeout = deploy_timeout + boot_timeout + install_fastboot_timeout + target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% else %}
+{% set job_timeout = target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% endif %}
 
 {# auto_login_* #}
 {% set AUTO_LOGIN_PROMPT = AUTO_LOGIN_PROMPT|default("login:") %}

--- a/master.jinja2
+++ b/master.jinja2
@@ -10,9 +10,9 @@
 {% set TEST_DEFINITIONS_REPOSITORY = TEST_DEFINITIONS_REPOSITORY|default("https://github.com/Linaro/test-definitions.git") %}
 
 {% if lxc_project == true %}
-{% set job_timeout = deploy_timeout + boot_timeout + install_fastboot_timeout + calc_target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% set job_timeout = deploy_timeout + boot_timeout + install_fastboot_timeout + calc_target_deploy_timeout + calc_boot_timeout + test_timeout %}
 {% else %}
-{% set job_timeout = calc_target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% set job_timeout = calc_target_deploy_timeout + calc_boot_timeout + test_timeout %}
 {% endif %}
 
 {# auto_login_* #}

--- a/master.jinja2
+++ b/master.jinja2
@@ -10,9 +10,9 @@
 {% set TEST_DEFINITIONS_REPOSITORY = TEST_DEFINITIONS_REPOSITORY|default("https://github.com/Linaro/test-definitions.git") %}
 
 {% if lxc_project == true %}
-{% set job_timeout = deploy_timeout + boot_timeout + install_fastboot_timeout + target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% set job_timeout = deploy_timeout + boot_timeout + install_fastboot_timeout + calc_target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
 {% else %}
-{% set job_timeout = target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% set job_timeout = calc_target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
 {% endif %}
 
 {# auto_login_* #}


### PR DESCRIPTION
if the job is not the lxc lava jobs, then we should not add the timeout value for lxc(deploy/boot/fastboot) actions to the job_timeout, and when we have one download deploy action for the images downloading, it's better to use a separate timeout variant instead of the same target_deploy_timeout which is mainly used for the fastboot deploy action(or other deploy actions)

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>