### PR TITLE
master.jinja2: fix the calculation of job_timeout

### DIFF
--- a/master.jinja2
+++ b/master.jinja2
@@ -9,7 +9,11 @@
 {% set test_timeout = test_timeout|default(60) %}
 {% set TEST_DEFINITIONS_REPOSITORY = TEST_DEFINITIONS_REPOSITORY|default("https://github.com/Linaro/test-definitions.git") %}
 
+{% if lxc_project == true %}
 {% set job_timeout = deploy_timeout + boot_timeout + install_fastboot_timeout + target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% else %}
+{% set job_timeout = target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% endif %}
 
 {# auto_login_* #}
 {% set AUTO_LOGIN_PROMPT = AUTO_LOGIN_PROMPT|default("login:") %}


### PR DESCRIPTION
fix to only add lxc_xxx_timeout when it's for the lcx_project

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>