### PR TITLE
devices/x15: make it possible for other boot_method

### DIFF
--- a/devices/x15
+++ b/devices/x15
@@ -4,7 +4,7 @@
 {% set DEPLOY_OS = DEPLOY_OS|default("oe") %}
 {% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("gz") %}
 
-{% set boot_method = "u-boot" %}
+{% set boot_method = boot_method|default("u-boot") %}
 {# libhugetlbfs_word_size variable is required for libhugetlbfs.yaml test template #}
 {% set libhuggetlbfs_word_size = 32 %}
 {% set pre_boot_command = false %}


### PR DESCRIPTION
currently the boot_method is hard coded as u-boot,
there are cases that we could boot the x15 devices
via fastboot as well, hence the change here to make
it possible to override the boot_method when necessary

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>