### PR TITLE
add a fastboot_deploy_timeout variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Overall job timeout is a sum of action timeouts. There are 6 components:
  * *deploy_timeout*
  * *boot_timeout*
  * *install_fastboot_timeout*
+ * *fastboot_deploy_timeout*
  * *target_deploy_timeout*
  * *TARGET_BOOT_TIMEOUT*
  * *test_timeout*

--- a/fastboot.jinja2
+++ b/fastboot.jinja2
@@ -4,7 +4,7 @@
 {{ super() }}
 - deploy:
     timeout:
-      minutes: {{ target_deploy_timeout }}
+      minutes: {{ fastboot_deploy_timeout }}
     to: fastboot
     docker:
       image: {{DOCKER_IMAGE}}

--- a/include/fastboot.jinja2
+++ b/include/fastboot.jinja2
@@ -18,6 +18,7 @@
 {% set pre_os_command = pre_os_command|default(true) %}
 {% set auto_login = auto_login|default(true) %}
 {% set boot_method = boot_method|default("fastboot") %}
+{% set fastboot_deploy_timeout = fastboot_deploy_timeout|default(40) %}
 
 {% block global_settings %}
 {{ super() }}

--- a/master.jinja2
+++ b/master.jinja2
@@ -4,15 +4,17 @@
 {% set deploy_timeout = deploy_timeout|default(15) %}
 {% set boot_timeout = boot_timeout|default(5) %}
 {% set install_fastboot_timeout = install_fastboot_timeout|default(10) %}
+{# fastboot_deploy_timeout is for 'to: fastboot' targets only #}
+{% set fastboot_deploy_timeout = fastboot_deploy_timeout|default(0) %}
 {% set target_deploy_timeout = target_deploy_timeout|default(40) %}
 {% set TARGET_BOOT_TIMEOUT = TARGET_BOOT_TIMEOUT|default(15)|int %}
 {% set test_timeout = test_timeout|default(60) %}
 {% set TEST_DEFINITIONS_REPOSITORY = TEST_DEFINITIONS_REPOSITORY|default("https://github.com/Linaro/test-definitions.git") %}
 
 {% if lxc_project == true %}
-{% set job_timeout = deploy_timeout + boot_timeout + install_fastboot_timeout + target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% set job_timeout = deploy_timeout + boot_timeout + install_fastboot_timeout + fastboot_deploy_timeout + target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
 {% else %}
-{% set job_timeout = target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% set job_timeout = fastboot_deploy_timeout + target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
 {% endif %}
 
 {# auto_login_* #}

--- a/projects/lkft/fastboot.jinja2
+++ b/projects/lkft/fastboot.jinja2
@@ -19,7 +19,7 @@
 
 - deploy:
     timeout:
-      minutes: {{ target_deploy_timeout }}
+      minutes: {{ fastboot_deploy_timeout }}
     to: fastboot
     docker:
       image: {{DOCKER_IMAGE}}


### PR DESCRIPTION
The job_timeout is calculated wrong when running fastboot jobs.
Only caclulate target_deploy_timeout once. Instead of calculate it twice
just split up the fastboot deploy with its own timeout variable
'fastboot_deploy_timeout'. Leave the first target_deploy_timeout as is
even if it does 'to: download' and not 'to: target'

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>