### PR TITLE
timeout calculation: add the (pre|post)_boot_timeout

### DIFF
--- a/master.jinja2
+++ b/master.jinja2
@@ -9,10 +9,16 @@
 {% set test_timeout = test_timeout|default(60) %}
 {% set TEST_DEFINITIONS_REPOSITORY = TEST_DEFINITIONS_REPOSITORY|default("https://github.com/Linaro/test-definitions.git") %}
 
+{# timeout for the pre_boot_command and post_boot_command blocks defined in include/fastboot.jinja2 #}
+{# if there are time consuming actions definded for them, then calc_boot_timeout will include the timeout for them #}
+{% set pre_boot_timeout = pre_boot_timeout|default(0) %}
+{% set post_boot_timeout = post_boot_timeout|default(0) %}
+{% set calc_boot_timeout = pre_boot_timeout + TARGET_BOOT_TIMEOUT + post_boot_timeout %}
+
 {% if lxc_project == true %}
-{% set job_timeout = deploy_timeout + boot_timeout + install_fastboot_timeout + target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% set job_timeout = deploy_timeout + boot_timeout + install_fastboot_timeout + target_deploy_timeout + calc_boot_timeout + test_timeout %}
 {% else %}
-{% set job_timeout = target_deploy_timeout + TARGET_BOOT_TIMEOUT + test_timeout %}
+{% set job_timeout = target_deploy_timeout + calc_boot_timeout + test_timeout %}
 {% endif %}
 
 {# auto_login_* #}


### PR DESCRIPTION
Like this job here:
    https://lkft.validation.linaro.org/scheduler/job/5005860/definition#defline75

There are pre_os_command, pre_power_command, pre_os_command commands specified,
and there is a default timeout value(30s) for them but ignored,.

The commands are defined via the pre_boot_command and post_boot_command blocks
in the include/fastboot.jinja2 file, and it's OK to ignore them for this case
as the value is very little, but if we define time consuming jobs via the
pre_boot_command and post_boot_command blocks, the job timeout value difference
will be obvious.

Hence this change to add the (pre|post)_boot_timeout variables
so that we could specify the timeout values for the time consuming actions
when necessary.

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>