### PR TITLE
testcases: kselftest-net: enable 'net.forwarding' and 'net.mptcp'

### DIFF
--- a/testcases/kselftests-net.yaml
+++ b/testcases/kselftests-net.yaml
@@ -1,4 +1,4 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
-{% set testnames = ['net', 'netfilter', 'nsfs', 'tc-testing'] %}
+{% set testnames = ['net', 'net.forwarding', 'net.mptcp', 'netfilter', 'nsfs', 'tc-testing'] %}
 {% set test_timeout = 15 %}


### PR DESCRIPTION
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>