### PR TITLE
template-master.jinja2: Put test_name after BUILD_NUMBER for job_name

### DIFF
--- a/testcases/master/template-master.jinja2
+++ b/testcases/master/template-master.jinja2
@@ -5,7 +5,10 @@
 {% set KERNEL_BRANCH = KERNEL_BRANCH|default("") %}
 {% set OS_INFO = OS_INFO|default("") %}
 
-{% block job_name %}{{PROJECT_NAME}}-{{OS_INFO}}-{{test_name}}-{{KERNEL_BRANCH}}-{{BUILD_NUMBER}}{% endblock job_name %}
+{# with the BUILD_NUMBER in the middle, it's possible to get #}
+{# the sub job name(which is the test_name here) #}
+{# from this lava job name information #}
+{% block job_name %}{{PROJECT_NAME}}-{{OS_INFO}}-{{KERNEL_BRANCH}}-{{BUILD_NUMBER}}-{{test_name}}{% endblock job_name %}
 
 {% block context %}
 {{ super() }}


### PR DESCRIPTION
With the BUILD_NUMBER in the middle, it's possible to get
the sub job name from the lava job name information.
which would help to check if the lava job is one newly resubmitted.

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>