### PR TITLE
testcases: template: kselftest: no '.' in name field

### DIFF
--- a/testcases/master/template-kselftest.yaml.jinja2
+++ b/testcases/master/template-kselftest.yaml.jinja2
@@ -39,7 +39,7 @@
       from: git
       revision: '{{ TDEFINITIONS_REVISION }}'
       path: automated/linux/kselftest/kselftest.yaml
-      name: kselftest-{{testname}}{{vsyscall_suffix}}
+      name: kselftest-{{testname|replace('.', '-')}}{{vsyscall_suffix}}
       parameters:
         TST_CMDFILES: '{{testname}}'
         KSELFTEST_PATH: {{KSELFTEST_PATH}}


### PR DESCRIPTION
The test-name can't contain '.' in it.

error_msg: Invalid job data: ['Invalid characters found in test
definition name: kselftest-net.forwarding', 'Invalid characters found in
test definition name: kselftest-net.mptcp']

Replace '.' with '-' in the name.

Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>