### PR TITLE
hip07-d05 device and Tensorflow MLPerf tests

### DIFF
--- a/devices/hip07-d05
+++ b/devices/hip07-d05
@@ -1,0 +1,24 @@
+{% set PROJECT = PROJECT|default("") %}
+{% extends PROJECT+"nfs.jinja2" %}
+
+{% set BOOT_OS_PROMPT = BOOT_OS_PROMPT|default("root@d05bench:~#") %}
+
+{% set auto_login = true %}
+{% set boot_method = "grub" %}
+{% set rootfs_label="nfsrootfs" %}
+{% set use_context = true %}
+
+{% block context %}
+  test_character_delay: 10
+{% endblock context %}
+
+{% block device_type %}synquacer{% endblock %}
+
+{% block boot_commands %}
+    commands:
+      - linux (hd0,gpt2)/boot/vmlinuz root=/dev/sda2
+      - initrd (hd0,gpt2)/boot/initrd.img
+      - boot
+    parameters:
+      shutdown-message: "reboot: Restarting system"
+{% endblock boot_commands %}

--- a/testcases/imagenet-resnet50-benchmark.yaml
+++ b/testcases/imagenet-resnet50-benchmark.yaml
@@ -1,0 +1,10 @@
+{% extends "testcases/master/template-test.jinja2" %}
+
+{% set test_timeout = 35 %}
+{% block metadata %}
+  {{ super() }}
+{% endblock metadata %}
+
+{% set test_name = test_name | default("imagenet-resnet50") %}
+{% set test_suite_name = "tensorflow" %}
+{% set test_path_file = 'automated/linux/tensorflow/imagenet-resnet50.yaml' %}

--- a/testcases/imagenet-ssd-resnet32-benchmark.yaml
+++ b/testcases/imagenet-ssd-resnet32-benchmark.yaml
@@ -1,0 +1,10 @@
+{% extends "testcases/master/template-test.jinja2" %}
+
+{% set test_timeout = 35 %}
+{% block metadata %}
+  {{ super() }}
+{% endblock metadata %}
+
+{% set test_name = test_name | default("imagenet-ssd-resnet32") %}
+{% set test_suite_name = "tensorflow" %}
+{% set test_path_file = 'automated/linux/tensorflow/imagenet-ssd-resnet32.yaml' %}

--- a/testcases/ssd-mobilenet-benchmark.yaml
+++ b/testcases/ssd-mobilenet-benchmark.yaml
@@ -1,0 +1,10 @@
+{% extends "testcases/master/template-test.jinja2" %}
+
+{% set test_timeout = 35 %}
+{% block metadata %}
+  {{ super() }}
+{% endblock metadata %}
+
+{% set test_name = test_name | default("ssd-mobilenet") %}
+{% set test_suite_name = "tensorflow" %}
+{% set test_path_file = 'automated/linux/tensorflow/ssd-mobilenet.yaml' %}


### PR DESCRIPTION
Creating D05 device definition, as well as mlperf tests to be run on the device: imagenet-ssd-resnet32, imagenet-resnet50, ssd-mobilenet.

The D05 device definition bypasses the NFS and boots to disk as performance is an important factor when running theses tests.

Signed-off-by: Theodore Grey <theodore.grey@linaro.org>