### PR TITLE
testcases: master: template-ltp.yaml.jinja2: set default TIMEOUT_MULT…

### DIFF
--- a/lava_test_plans/testcases/master/template-ltp.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-ltp.yaml.jinja2
@@ -30,7 +30,7 @@
         BOARD: '{{ DEVICE_TYPE }}'
         BRANCH: '{{ SKIPGEN_KERNEL_VERSION|default('default') }}'
         ENVIRONMENT: '{{ ENVIRONMENT|default('production') }}'
-        TIMEOUT_MULTIPLIER: '{{ TIMEOUT_MULTIPLIER|default('3') }}'
+        TIMEOUT_MULTIPLIER: '{{ TIMEOUT_MULTIPLIER|default('10') }}'
         LTP_TMPDIR: '/scratch'
       name: ltp-{{testname|replace('.','-')}}{{LAVA_TEST_NAME_SUFFIX}}
 {% endfor %}


### PR DESCRIPTION
…IPLIER to 30

LTP each test timeout value reduced from 300sec to 30sec. So this change will make sure we set each test time to 30sec * 30 times which is 900 sec.

setting up TIMEOUT_MULTIPLIER to 30.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>