### PR TITLE
devices: juno/x15/x86: Update mkfs -t ext4 -> mkfs.ext4

### DIFF
--- a/lava_test_plans/devices/juno-r2
+++ b/lava_test_plans/devices/juno-r2
@@ -43,7 +43,7 @@
           steps:
           - export STORAGE_DEV=$(lava-target-storage SATA || lava-target-storage USB)
           - test -n "${STORAGE_DEV}" || lava-test-raise "STORAGE_DEV not found; job exit"
-          - echo "y" | mkfs -t ext4 ${STORAGE_DEV} || lava-test-raise "mkfs -t ext4 ${STORAGE_DEV} failed; job exit"
+          - echo "y" | mkfs.ext4 ${STORAGE_DEV} || lava-test-raise "mkfs.ext4 ${STORAGE_DEV} failed; job exit"
           - mkdir -p /scratch
           - mount ${STORAGE_DEV} /scratch && echo "mounted" || lava-test-raise "mount ${STORAGE_DEV} failed; job exit"
           - df -h

--- a/lava_test_plans/devices/x15
+++ b/lava_test_plans/devices/x15
@@ -42,7 +42,7 @@
 {% if SKIPGEN_KERNEL_VERSION != '4.4' or SKIPGEN_KERNEL_VERSION != 'linux-4.4.y' %}
           - export STORAGE_DEV=$(lava-target-storage SATA || lava-target-storage USB)
           - test -n "${STORAGE_DEV}" || lava-test-raise "STORAGE_DEV not found; job exit"
-          - echo "y" | mkfs -t ext4 ${STORAGE_DEV} || lava-test-raise "mkfs -t ext4 ${STORAGE_DEV} failed; job exit"
+          - echo "y" | mkfs.ext4 ${STORAGE_DEV} || lava-test-raise "mkfs.ext4 ${STORAGE_DEV} failed; job exit"
           - mkdir -p /scratch
           - mount ${STORAGE_DEV} /scratch && echo "mounted" || lava-test-raise "mount ${STORAGE_DEV} failed; job exit"
 {% endif %}

--- a/lava_test_plans/devices/x86
+++ b/lava_test_plans/devices/x86
@@ -43,7 +43,7 @@
           steps:
           - export STORAGE_DEV=$(lava-target-storage SATA || lava-target-storage USB)
           - test -n "${STORAGE_DEV}" || lava-test-raise "STORAGE_DEV not found; job exit"
-          - echo "y" | mkfs -t ext4 ${STORAGE_DEV} || lava-test-raise "mkfs -t ext4 ${STORAGE_DEV} failed; job exit"
+          - echo "y" | mkfs.ext4 ${STORAGE_DEV} || lava-test-raise "mkfs.ext4 ${STORAGE_DEV} failed; job exit"
           - mkdir -p /scratch
           - mount ${STORAGE_DEV} /scratch && echo "mounted" || lava-test-raise "mount ${STORAGE_DEV} failed; job exit"
           - df -h


### PR DESCRIPTION
Because we are expecting to make an EXT4 file system, the `mkfs.ext4` command has to exist. The `mkfs` helper command, however, may not exist in the DUT root file system.