### PR TITLE
submit_for_testing: do not hardcode python3 path

### DIFF
--- a/submit_for_testing.py
+++ b/submit_for_testing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2022-present Linaro Limited
 #
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
I faced a situation where I had two python3 versions on a docker container, 3.9 on top of /usr/bin and 3.8 on top of /usr/local/bin, on other words

  ~# ls -la $(which python3)
  lrwxrwxrwx 1 root root 9 Aug  2 11:49 /usr/local/bin/python3 -> python3.8
  ~# ls -la /usr/bin/python3
  lrwxrwxrwx 1 root root 9 Apr  5  2021 /usr/bin/python3 -> python3.9

and pip3 using the python 3.8 version. Under this scenario, installing packages through pip3 will not be 'visible' for the submission script which uses python 3.9 , thus letting 'env' decide the python interpreter is the safest approach.

Signed-off-by: Leonardo Sandoval <leonardo.sandoval@linaro.org>