### PR TITLE
testcases: kselftest: arm64: Increase timeout to 65 minutes

### DIFF
--- a/lava_test_plans/testcases/kselftests-arm64.yaml
+++ b/lava_test_plans/testcases/kselftests-arm64.yaml
@@ -1,4 +1,4 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set testnames = ['arm64'] %}
-{% set test_timeout = 15 %}
+{% set test_timeout = 65 %}


### PR DESCRIPTION
kselftest arm64 have been added with multiple new test cases due to this the test run time increased to 65 minutes.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>