### PR TITLE
projects: lkft: fastboot: drop passing 'ROOTFS_IMAGE_NAME'

### DIFF
--- a/lava_test_plans/projects/lkft/fastboot.jinja2
+++ b/lava_test_plans/projects/lkft/fastboot.jinja2
@@ -10,13 +10,12 @@
 {% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("ptable-linux-8g.img") %}
 {% set DOCKER_BOOT_FILE = DOCKER_BOOT_FILE|default("boot.img") %}
 {% set DOCKER_ROOTFS_FILE = DOCKER_ROOTFS_FILE|default("rpb-console-image-lkft.rootfs.img") %}
-{% set ROOTFS_IMAGE_NAME = ROOTFS_IMAGE_NAME|default("lkft-console-image") %}
 
 {% block deploy_target %}
 {{ super() }}
 {% if DEPLOY_TARGET == "downloads" %}
         steps:
-        - /kir/lava/board_setup.sh {{DEVICE_TYPE}} {{ROOTFS_IMAGE_NAME}}
+        - /kir/lava/board_setup.sh {{DEVICE_TYPE}}
 
 - deploy:
     timeout:


### PR DESCRIPTION
Drop passing 'ROOTFS_IMAGE_NAME' to kir's board_setup script.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>