### PR TITLE
testcases: ltp-cve: drop 'TIMEOUT_MULTIPLIER=1'

### DIFF
--- a/lava_test_plans/testcases/ltp-cve.yaml
+++ b/lava_test_plans/testcases/ltp-cve.yaml
@@ -2,4 +2,3 @@
 
 {% set testnames = ['cve'] %}
 {% set test_timeout = 60 %}
-{% set TIMEOUT_MULTIPLIER = 1 %}


### PR DESCRIPTION
Default TIMEOUT_MULTIPLIER is set to 10, That's needed for ltp-cve too.

Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>