### PR TITLE
kselftests: Bump kselftests timeout values

### DIFF
--- a/lava_test_plans/testcases/kselftests-arm64.yaml
+++ b/lava_test_plans/testcases/kselftests-arm64.yaml
@@ -1,4 +1,4 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set testnames = ['arm64'] %}
-{% set test_timeout = 65 %}
+{% set test_timeout = 95 %}

--- a/lava_test_plans/testcases/kselftests-bpf.yaml
+++ b/lava_test_plans/testcases/kselftests-bpf.yaml
@@ -1,4 +1,4 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set testnames = ['bpf'] %}
-{% set test_timeout = 15 %}
+{% set test_timeout = 45 %}

--- a/lava_test_plans/testcases/kselftests-drivers.yaml
+++ b/lava_test_plans/testcases/kselftests-drivers.yaml
@@ -2,4 +2,4 @@
 
 {% set guestfs_size = 1024 %}
 {% set testnames = ['drivers.dma-buf'] %}
-{% set test_timeout = 10 %}
+{% set test_timeout = 30 %}

--- a/lava_test_plans/testcases/kselftests-intel-x86.yaml
+++ b/lava_test_plans/testcases/kselftests-intel-x86.yaml
@@ -1,4 +1,4 @@
 {% extends "testcases/master/template-kselftest.yaml.jinja2" %}
 
 {% set testnames = ['intel_pstate', 'livepatch', 'ptrace', 'x86'] %}
-{% set test_timeout = 15 %}
+{% set test_timeout = 45 %}

--- a/lava_test_plans/testcases/kselftests-kvm.yaml
+++ b/lava_test_plans/testcases/kselftests-kvm.yaml
@@ -1,4 +1,4 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set testnames = ['kvm'] %}
-{% set test_timeout = 15 %}
+{% set test_timeout = 45 %}

--- a/lava_test_plans/testcases/kselftests-lkdtm.yaml
+++ b/lava_test_plans/testcases/kselftests-lkdtm.yaml
@@ -1,4 +1,4 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set testnames = ['lkdtm'] %}
-{% set test_timeout = 10 %}
+{% set test_timeout = 30 %}

--- a/lava_test_plans/testcases/kselftests-net-2.yaml
+++ b/lava_test_plans/testcases/kselftests-net-2.yaml
@@ -1,4 +1,4 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set testnames = ['netfilter', 'nsfs', 'tc-testing'] %}
-{% set test_timeout = 15 %}
+{% set test_timeout = 45 %}

--- a/lava_test_plans/testcases/kselftests-short-run-1.yaml
+++ b/lava_test_plans/testcases/kselftests-short-run-1.yaml
@@ -2,4 +2,4 @@
 
 {% set guestfs_size = 1024 %}
 {% set testnames = ['breakpoints', 'capabilities', 'cgroup', 'clone3', 'core', 'cpufreq', 'cpu-hotplug'] %}
-{% set test_timeout = 20 %}
+{% set test_timeout = 40 %}

--- a/lava_test_plans/testcases/kselftests-short-run-2.yaml
+++ b/lava_test_plans/testcases/kselftests-short-run-2.yaml
@@ -2,4 +2,4 @@
 
 {% set guestfs_size = 1024 %}
 {% set testnames = ['efivarfs', 'filesystems',  'filesystems.binderfs', 'filesytems.epoll', 'firmware', 'fpu', 'ftrace', 'futex'] %}
-{% set test_timeout = 20 %}
+{% set test_timeout = 40 %}

--- a/lava_test_plans/testcases/kselftests-short-run-3.yaml
+++ b/lava_test_plans/testcases/kselftests-short-run-3.yaml
@@ -2,4 +2,4 @@
 
 {% set guestfs_size = 1024 %}
 {% set testnames = ['lib', 'membarrier', 'memfd', 'memory-hotplug', 'mincore', 'mount', 'mqueue'] %}
-{% set test_timeout = 15 %}
+{% set test_timeout = 45 %}

--- a/lava_test_plans/testcases/kselftests-short-run-4.yaml
+++ b/lava_test_plans/testcases/kselftests-short-run-4.yaml
@@ -2,4 +2,4 @@
 
 {% set guestfs_size = 1024 %}
 {% set testnames = ['seccomp', 'sigaltstack', 'size', 'splice', 'static_keys', 'sync', 'sysctl'] %}
-{% set test_timeout = 15 %}
+{% set test_timeout = 45 %}

--- a/lava_test_plans/testcases/kselftests-short-run-5.yaml
+++ b/lava_test_plans/testcases/kselftests-short-run-5.yaml
@@ -2,4 +2,4 @@
 
 {% set guestfs_size = 1024 %}
 {% set testnames = ['timens', 'timers', 'tmpfs', 'tpm2', 'user', 'vm', 'zram'] %}
-{% set test_timeout = 20 %}
+{% set test_timeout = 40 %}

--- a/lava_test_plans/testcases/kselftests-short-run-6.yaml
+++ b/lava_test_plans/testcases/kselftests-short-run-6.yaml
@@ -2,4 +2,4 @@
 
 {% set guestfs_size = 1024 %}
 {% set testnames = ['openat2', 'pidfd', 'pid_namespace', 'pstore', 'proc'] %}
-{% set test_timeout = 20 %}
+{% set test_timeout = 40 %}

--- a/lava_test_plans/testcases/kselftests-short-run-7.yaml
+++ b/lava_test_plans/testcases/kselftests-short-run-7.yaml
@@ -2,4 +2,4 @@
 
 {% set guestfs_size = 1024 %}
 {% set testnames = ['gpio', 'ipc', 'ir', 'kcmp', 'kexec','rseq', 'rtc'] %}
-{% set test_timeout = 20 %}
+{% set test_timeout = 40 %}


### PR DESCRIPTION
A large set of kselftest timedout on emulation platforms due
to short timeout values. This commit is increasing the test run
time values.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>