### PR TITLE
projects: lkft: metadata: add build_json_artifact_url

### DIFF
--- a/lava_test_plans/projects/lkft/include/metadata.jinja2
+++ b/lava_test_plans/projects/lkft/include/metadata.jinja2
@@ -8,3 +8,4 @@
   artifact-location: {{KERNEL_ARCH_ARTIFACTS_PUB_DEST | default('""')}}
   toolchain: {{TOOLCHAIN | default('unknown')}}
   email-notification: {{CI_MAIL_RECIPIENTS | default('""')}}
+  build_json_artifact_url: {{BUILD_JSON_ARTIFACT_URL | default('""')}}


### PR DESCRIPTION
This is needed so SQUAD can pull the 'build_name' when pulling LAVA jobs.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>