### PR TITLE
Makefile: drop parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: typecheck test style flake8
 
 export PROJECT := lava_test_plans
-export NUM_WORKERS=$(shell nproc)
+#export NUM_WORKERS=$(shell nproc)
 export TUXPKG_MIN_COVERAGE := 45
 
 include $(shell tuxpkg get-makefile)


### PR DESCRIPTION
Drop parallel builds for now since the following error shows up in the pipeline with that enabled:

INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/_pytest/main.py", line 266, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1037, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/pluggy/_hooks.py", line 277, in call_historic
INTERNALERROR>     res = self._hookexec(self.name, self.get_hookimpls(), kwargs, False)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 80, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 60, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/pluggy/_result.py", line 60, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 39, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/pytest_parallel/__init__.py", line 111, in pytest_configure
INTERNALERROR>     config.pluginmanager.register(ParallelRunner(config), 'parallelrunner')
INTERNALERROR>                                   ^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/pytest_parallel/__init__.py", line 196, in __init__
INTERNALERROR>     self._log = py.log.Producer('pytest-parallel')
INTERNALERROR>                 ^^^^^^
INTERNALERROR> AttributeError: module 'py' has no attribute 'log'
make: *** [/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/tuxpkg/data/tuxpkg.mk:10: test] Error 3
Error: Process completed with exit code 2.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>