### PR TITLE
Makefile: re-enable parallel tests

### DIFF
--- a/.github/workflows/test-plans-pipeline.yml
+++ b/.github/workflows/test-plans-pipeline.yml
@@ -22,6 +22,7 @@ jobs:
          pip install black
          pip install flit
          pip install tuxpkg
+         pip install py
          pip install pytest
          pip install pytest-cov
          pip install pytest-parallel

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: typecheck test style flake8
 
 export PROJECT := lava_test_plans
-#export NUM_WORKERS=$(shell nproc)
+export NUM_WORKERS=$(shell nproc)
 export TUXPKG_MIN_COVERAGE := 45
 
 include $(shell tuxpkg get-makefile)


### PR DESCRIPTION
From this link [1] it looks like installing 'py' will solve the issue.

Link: https://github.com/kevlened/pytest-parallel/issues/118
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>