### PR TITLE
Makefile: update the PROJECT name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: typecheck test style flake8
 
-export PROJECT := lava_test_plans
+export PROJECT := lava-test-plans
 export NUM_WORKERS=$(shell nproc)
 export TUXPKG_MIN_COVERAGE := 57
 


### PR DESCRIPTION
The PROJECT variable should be set to lava-test-plans, and the MODULE variable will be set to lava_test_plans.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>