### PR TITLE
gitlab-ci: update the build-arg

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ services:
     - export tag="lavasoftware/lava-test-plans:${CI_COMMIT_TAG}${TAG_APPEND}"
     - export latest="lavasoftware/lava-test-plans:latest${TAG_APPEND}"
   script:
-    - docker build --build-arg version="${tag}" --pull --tag "${tag}" --tag "${latest}" .
+    - docker build --build-arg version="${CI_COMMIT_TAG}" --pull --tag "${tag}" --tag "${latest}" .
     - docker push "${tag}"
     - docker push "${latest}"
   variables:
@@ -46,7 +46,7 @@ docker-arm64:
   variables:
     IMAGE_NAME: "lavasoftware/lava-test-plans:master"
   script:
-    - docker build --build-arg version="master-${CI_COMMIT_SHORT_SHA}" --pull --tag "${IMAGE_NAME}${TAG_APPEND}" .
+    - docker build --build-arg version="${CI_COMMIT_SHORT_SHA}" --pull --tag "${IMAGE_NAME}${TAG_APPEND}" .
     - docker push "${IMAGE_NAME}${TAG_APPEND}"
   only:
     - master


### PR DESCRIPTION
Update the build-arg sent in to the containers that will be published to lavasoftware/test-plans.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>