### PR TITLE
Dockerfile.ci-*: drop hardcoded tuxpkg versions

### DIFF
--- a/Dockerfile.ci-debian
+++ b/Dockerfile.ci-debian
@@ -23,6 +23,6 @@ RUN if grep '^Source: tuxpkg' /tuxpkg/debian/control; then exit; fi; \
     /usr/lib/apt/apt-helper download-file https://linaro.gitlab.io/tuxpkg/packages/signing-key.gpg /etc/apt/trusted.gpg.d/tuxpkg.gpg \
     && echo 'deb https://linaro.gitlab.io/tuxpkg/packages/ ./' > /etc/apt/sources.list.d/tuxpkg.list \
     && apt-get update \
-    && apt-get install -q=2 -y tuxpkg=0.9.0-1
+    && apt-get install -q=2 -y tuxpkg
 
 # vim: ft=dockerfile

--- a/Dockerfile.ci-fedora
+++ b/Dockerfile.ci-fedora
@@ -7,6 +7,6 @@ RUN dnf install -y dnf-plugins-core rpm-build ${EXTRA_PACKAGES} \
 
 RUN if [ -f /tuxpkg/tuxpkg.spec ]; then exit; fi; \
     printf '[tuxpkg]\nname=tuxpkg\ntype=rpm-md\nbaseurl=https://linaro.gitlab.io/tuxpkg/packages/\ngpgcheck=1\ngpgkey=https://linaro.gitlab.io/tuxpkg/packages/repodata/repomd.xml.key\nenabled=1\n' > /etc/yum.repos.d/tuxpkg.repo \
-    && dnf install -y tuxpkg-0.9.0
+    && dnf install -y tuxpkg
 
 # vim: ft=dockerfile


### PR DESCRIPTION
There is now a schedules pipeline that will rebuild the images weekly.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>