### PR TITLE
plans: lkft-full: drop libhugetlbfs tests

### DIFF
--- a/lava_test_plans/testplans/lkft-full/libhugetlbfs.yaml
+++ b/lava_test_plans/testplans/lkft-full/libhugetlbfs.yaml
@@ -1,1 +1,0 @@
-../../testcases/libhugetlbfs.yaml


### PR DESCRIPTION
Our libhugetlbfs tests fails since there isn't any support in OE [1] since moving from glibc 2.34+.
So lets drop it from the full testplan for LKFT.

Link: https://www.mail-archive.com/openembedded-devel@lists.openembedded.org/msg78304.html
Link: https://github.com/libhugetlbfs/libhugetlbfs/issues/52
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>