### PR TITLE
lava_test_plans: kselftests: bump net tests timeout to 60 mins

### DIFF
--- a/lava_test_plans/testcases/kselftests-net.yaml
+++ b/lava_test_plans/testcases/kselftests-net.yaml
@@ -1,4 +1,4 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set testnames = ['net'] %}
-{% set test_timeout = 30 %}
+{% set test_timeout = 60 %}


### PR DESCRIPTION
since upstream selftests net is getting more test cases the LAVA test plans running on LAVA and tuxruns need 30 min more time. This patch is increasing timeout value from 30 to 60 minutes.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>