### PR TITLE
lkft-android: add common post boot actions

### DIFF
--- a/lava_test_plans/include/test_target.jinja2
+++ b/lava_test_plans/include/test_target.jinja2
@@ -1,5 +1,11 @@
+{% set USE_DOCKER_IMAGE_FOR_TEST_TARGET = USE_DOCKER_IMAGE_FOR_TEST_TARGET|default(false) %}
+
 {% if enable_tests is defined and enable_tests %}
 - test:
+{% if USE_DOCKER_IMAGE_FOR_TEST_TARGET == true %}
+    docker:
+      image: {{ DOCKER_IMAGE_FOR_TEST }}
+{% endif %}
 {% if lxc_project == true %}
     namespace: target
 {% endif %}

--- a/lava_test_plans/projects/lkft-android/fastboot.jinja2
+++ b/lava_test_plans/projects/lkft-android/fastboot.jinja2
@@ -94,3 +94,7 @@
 {% endblock deploy_fastboot %}
 {% endif %}
 {% endblock deploy_target %}
+
+{% block post_boot_command %}
+{% include PROJECT+"include/lkft-common-actions.jinja2" %}
+{% endblock post_boot_command %}

--- a/lava_test_plans/projects/lkft-android/fastboot.jinja2
+++ b/lava_test_plans/projects/lkft-android/fastboot.jinja2
@@ -5,6 +5,9 @@
 {% set target_deploy_timeout = target_deploy_timeout |default(35) %}
 {% set deploy_fastboot_timeout = deploy_fastboot_timeout|default(10) %}
 
+{# force all the lkft-android jobs to be run with the docker method #}
+{% set USE_DOCKER_IMAGE_FOR_TEST_TARGET = true %}
+
 {% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("ptable-linux-8g.img") %}
 {% set DOCKER_BOOT_FILE = DOCKER_BOOT_FILE|default("boot.img") %}
 {# use the same file name as for boot partition if no boot_a or boot_b images #}

--- a/lava_test_plans/projects/lkft-android/include/lkft-common-actions.jinja2
+++ b/lava_test_plans/projects/lkft-android/include/lkft-common-actions.jinja2
@@ -1,0 +1,39 @@
+{% set post_boot_interactive_timeout = post_boot_interactive_timeout|default(5) %}
+{% set post_boot_adb_commands_timeout = post_boot_adb_commands_timeout|default(5) %}
+
+{# enable_tests is set to false in testcases/boot.yaml #}
+{# but here are common actions which will be used for that boot job as well, #}
+{# so need to override that and set to true explictly #}
+{% with enable_tests=true, test_timeout=post_boot_interactive_timeout, test_target_interactive=true, USE_DOCKER_IMAGE_FOR_TEST_TARGET=false %}
+{% include "include/test_target.jinja2" %}
+{% endwith %}
+    - name: sleep-to-wait-adb-available
+{% filter indent(width=2, first=True)%}
+{% include "include/boot_target/boot_os_prompt.jinja2" %}
+{% endfilter %}
+      script:
+      - command: echo ===========================
+      - command: while ! getprop sys.boot_completed|grep 1; do echo sleep 10s for sys.boot_completed; sleep 10; done
+      - command: echo ===========================
+      - command: while ! getprop init.svc.adbd|grep running; do echo sleep 10s for init.svc.adbd; sleep 10; done
+      - command: echo ===========================
+      - command: getprop | grep adb
+      - command: echo ===========================
+
+{% with enable_tests=true, test_timeout=post_boot_adb_commands_timeout %}
+{% include "include/test_target.jinja2" %}
+{% endwith %}
+    - from: inline
+      path: android-boot.yaml
+      name: android-boot
+      repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: android-boot
+          description: "android-boot"
+        run:
+          steps:
+            - lava-test-case "android-boot-wait-for-device" --shell adb wait-for-device
+            - lava-test-case "android-boot-boot-completed" --shell "while ! adb shell getprop sys.boot_completed|grep 1; do sleep 2; done"
+            - lava-test-case "android-boot-set-power-stayon" --shell adb shell su 0 svc power stayon true
+            - lava-test-case "android-boot-screencap" --shell adb shell screencap -p /data/local/tmp/screencap.png

--- a/lava_test_plans/projects/lkft-android/variables.ini
+++ b/lava_test_plans/projects/lkft-android/variables.ini
@@ -31,3 +31,6 @@ PROJECT_NAME="lkft"
 DEPLOY_TARGET="fastboot"
 OS_INFO="android"
 DEPLOY_OS="android"
+
+#
+DOCKER_IMAGE_FOR_TEST="docker-hub-url"


### PR DESCRIPTION
to wait for the adb connection ready and to make sure the device is booted up to the home screen, so the real test could do the test directly to avoid such checks.

And the docker method is forced for the lkft-android projects now, as the lxc method is going to be dropped soon.