### PR TITLE
Kir: Update docker image to pull

### DIFF
--- a/lava_test_plans/projects/lkft/fastboot.jinja2
+++ b/lava_test_plans/projects/lkft/fastboot.jinja2
@@ -23,6 +23,7 @@
     to: fastboot
     docker:
       image: {{DOCKER_IMAGE}}
+    local: true
     images:
 {% if rootfs == true %}
 {% if ptable == true %}


### PR DESCRIPTION
This will stop us pulling from DockerHub. Right now kir is already pulled on the workers so this won't break anything. However LAVA source code needs to change to introduce pulling if the image is not there.