### PR TITLE
Preparation patch for pr-243

### DIFF
--- a/lava_test_plans/fastboot.jinja2
+++ b/lava_test_plans/fastboot.jinja2
@@ -7,7 +7,7 @@
       minutes: {{ fastboot_deploy_timeout }}
     to: fastboot
     docker:
-      image: {{DOCKER_IMAGE}}
+      image: {{DOCKER_IMAGE_DEPLOY}}
     images:
 {% if rootfs == true %}
 {% if ptable == true %}

--- a/lava_test_plans/include/fastboot.jinja2
+++ b/lava_test_plans/include/fastboot.jinja2
@@ -2,7 +2,8 @@
 
 {% set use_context = true %}
 
-{% set DOCKER_IMAGE = DOCKER_IMAGE|default("debian:buster") %}
+{% set DOCKER_IMAGE_DEPLOY = DOCKER_IMAGE_DEPLOY|default("debian:buster") %}
+{% set DOCKER_IMAGE_POSTPROCESS = DOCKER_IMAGE_POSTPROCESS|default("debian:buster") %}
 {% set ptable = ptable|default(false) %}
 {% set PTABLE_LABEL = PTABLE_LABEL|default("ptable") %}
 {% set reboot_reset = reboot_reset|default(false) %}
@@ -237,7 +238,7 @@ reboot_to_fastboot: {{ reboot_to_fastboot }}
 {% if lxc_project == false and download_postprocess_required == true %}
     postprocess:
       docker:
-        image: {{DOCKER_IMAGE}}
+        image: {{DOCKER_IMAGE_POSTPROCESS}}
 {% endif %}
 {% endblock deploy_target %}
 

--- a/lava_test_plans/include/test_target.jinja2
+++ b/lava_test_plans/include/test_target.jinja2
@@ -1,10 +1,10 @@
-{% set USE_DOCKER_IMAGE_FOR_TEST_TARGET = USE_DOCKER_IMAGE_FOR_TEST_TARGET|default(false) %}
+{% set USE_DOCKER_IMAGE_TEST_TARGET = USE_DOCKER_IMAGE_TEST_TARGET|default(false) %}
 
 {% if enable_tests is defined and enable_tests %}
 - test:
-{% if USE_DOCKER_IMAGE_FOR_TEST_TARGET == true %}
+{% if USE_DOCKER_IMAGE_TEST_TARGET == true %}
     docker:
-      image: {{ DOCKER_IMAGE_FOR_TEST }}
+      image: {{ DOCKER_IMAGE_TEST }}
 {% endif %}
 {% if lxc_project == true %}
     namespace: target

--- a/lava_test_plans/projects/lkft-android/fastboot.jinja2
+++ b/lava_test_plans/projects/lkft-android/fastboot.jinja2
@@ -40,7 +40,7 @@
       minutes: {{ deploy_fastboot_timeout }}
     to: fastboot
     docker:
-      image: {{ DOCKER_IMAGE }}
+      image: {{ DOCKER_IMAGE_DEPLOY }}
     images:
 {% if ptable == true %}
       {{ PTABLE_LABEL }}:

--- a/lava_test_plans/projects/lkft-android/fastboot.jinja2
+++ b/lava_test_plans/projects/lkft-android/fastboot.jinja2
@@ -6,7 +6,7 @@
 {% set deploy_fastboot_timeout = deploy_fastboot_timeout|default(10) %}
 
 {# force all the lkft-android jobs to be run with the docker method #}
-{% set USE_DOCKER_IMAGE_FOR_TEST_TARGET = true %}
+{% set USE_DOCKER_IMAGE_TEST_TARGET = true %}
 
 {% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("ptable-linux-8g.img") %}
 {% set DOCKER_BOOT_FILE = DOCKER_BOOT_FILE|default("boot.img") %}

--- a/lava_test_plans/projects/lkft-android/include/lkft-common-actions.jinja2
+++ b/lava_test_plans/projects/lkft-android/include/lkft-common-actions.jinja2
@@ -4,7 +4,7 @@
 {# enable_tests is set to false in testcases/boot.yaml #}
 {# but here are common actions which will be used for that boot job as well, #}
 {# so need to override that and set to true explictly #}
-{% with enable_tests=true, test_timeout=post_boot_interactive_timeout, test_target_interactive=true, USE_DOCKER_IMAGE_FOR_TEST_TARGET=false %}
+{% with enable_tests=true, test_timeout=post_boot_interactive_timeout, test_target_interactive=true, USE_DOCKER_IMAGE_TEST_TARGET=false %}
 {% include "include/test_target.jinja2" %}
 {% endwith %}
     - name: sleep-to-wait-adb-available

--- a/lava_test_plans/projects/lkft-android/variables.ini
+++ b/lava_test_plans/projects/lkft-android/variables.ini
@@ -33,4 +33,4 @@ OS_INFO="android"
 DEPLOY_OS="android"
 
 #
-DOCKER_IMAGE_FOR_TEST="docker-hub-url"
+DOCKER_IMAGE_TEST="docker-hub-url"

--- a/lava_test_plans/projects/lkft/fastboot.jinja2
+++ b/lava_test_plans/projects/lkft/fastboot.jinja2
@@ -6,7 +6,8 @@
 
 {% set BOOT_LABEL_OVERRIDE = BOOT_LABEL_OVERRIDE|default(false) %}
 {% set DEPLOY_TARGET = DEPLOY_TARGET|default("downloads") %}
-{% set DOCKER_IMAGE = DOCKER_IMAGE|default("linaro/kir:master") %}
+{% set DOCKER_IMAGE_DEPLOY = DOCKER_IMAGE_DEPLOY|default("linaro/kir:master") %}
+{% set DOCKER_IMAGE_POSTPROCESS = DOCKER_IMAGE_POSTPROCESS|default("linaro/kir:master") %}
 {% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("ptable-linux-8g.img") %}
 {% set DOCKER_BOOT_FILE = DOCKER_BOOT_FILE|default("boot.img") %}
 {% set DOCKER_ROOTFS_FILE = DOCKER_ROOTFS_FILE|default("rpb-console-image-lkft.rootfs.img") %}
@@ -22,7 +23,7 @@
       minutes: {{ fastboot_deploy_timeout }}
     to: fastboot
     docker:
-      image: {{DOCKER_IMAGE}}
+      image: {{DOCKER_IMAGE_DEPLOY}}
     images:
 {% if rootfs == true %}
 {% if ptable == true %}


### PR DESCRIPTION
This PR makes it possible to specify different docker images for deploy and post process, also cleanup the variable for the docker image used for testing.