### PR TITLE
lkft-android: add cts vts templates for android-mainline projects

### DIFF
--- a/lava_test_plans/projects/lkft-android/variables.ini
+++ b/lava_test_plans/projects/lkft-android/variables.ini
@@ -40,5 +40,14 @@ DEPLOY_OS="android"
 
 #
 DOCKER_IMAGE_TEST="docker-hub-url"
+
 #
 ARTIFACTORIAL_TOKEN="artifactorial-token"
+
+#
+TEST_CTS_URL="test-cts-url"
+TEST_VTS_URL="test-vts-url"
+TEST_CTS_VERSION="test-cts-version"
+TEST_VTS_VERSION="test-vts-version"
+TEST_CTS_SUITE_NAME="cts"
+TEST_VTS_SUITE_NAME="vts"

--- a/lava_test_plans/testcases/android-cts.yaml
+++ b/lava_test_plans/testcases/android-cts.yaml
@@ -1,0 +1,1 @@
+{% extends "testcases/master/template-android-cts.yaml.jinja2" %}

--- a/lava_test_plans/testcases/android-vts-kernel-v7a.yaml
+++ b/lava_test_plans/testcases/android-vts-kernel-v7a.yaml
@@ -1,0 +1,6 @@
+{% extends "testcases/master/template-android-vts.yaml.jinja2" %}
+
+{% set test_timeout = 480 %}
+{% set test_name = "vts-kernel-armeabi-v7a" %}
+
+{% block xts_test_params %}vts-kernel --abi armeabi-v7a{% endblock xts_test_params %}

--- a/lava_test_plans/testcases/android-vts-kernel-v8a.yaml
+++ b/lava_test_plans/testcases/android-vts-kernel-v8a.yaml
@@ -1,0 +1,6 @@
+{% extends "testcases/master/template-android-vts.yaml.jinja2" %}
+
+{% set test_timeout = 480 %}
+{% set test_name = "vts-kernel-arm64-v8a" %}
+
+{% block xts_test_params %}vts-kernel --abi arm64-v8a{% endblock xts_test_params %}

--- a/lava_test_plans/testcases/android-vts.yaml
+++ b/lava_test_plans/testcases/android-vts.yaml
@@ -1,0 +1,1 @@
+{% extends "testcases/master/template-android-vts.yaml.jinja2" %}

--- a/lava_test_plans/testcases/master/template-android-cts.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-android-cts.yaml.jinja2
@@ -1,0 +1,12 @@
+{% extends "testcases/master/template-android-xts.yaml.jinja2" %}
+
+{% set xts_test_url = TEST_CTS_URL %}
+{% set xts_version = TEST_CTS_VERSION %}
+{% set xts_test_suite_name = TEST_CTS_SUITE_NAME|default("cts") %}
+
+{% set xts_test_params = xts_test_params|default("cts") %}
+{% set test_name = test_name|default("cts") %}
+{% set xts_test_path = xts_test_path|default("android-cts") %}
+{% set xts_pkg_name = xts_pkg_name|default("android-cts.zip") %}
+{% set xts_metadata_prefix = xts_metadata_prefix|default("cts") %}
+{% set xts_expect_reboot = xts_expect_reboot|default(false) %}

--- a/lava_test_plans/testcases/master/template-android-vts.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-android-vts.yaml.jinja2
@@ -1,0 +1,12 @@
+{% extends "testcases/master/template-android-xts.yaml.jinja2" %}
+
+{% set xts_test_url = TEST_VTS_URL %}
+{% set xts_version = TEST_VTS_VERSION %}
+{% set xts_test_suite_name = TEST_VTS_SUITE_NAME|default("vts") %}
+
+{% set xts_test_params = xts_test_params|default("vts") %}
+{% set test_name = test_name|default("vts") %}
+{% set xts_test_path = xts_test_path|default("android-vts") %}
+{% set xts_pkg_name = xts_pkg_name|default("android-vts.zip") %}
+{% set xts_metadata_prefix = xts_metadata_prefix|default("vts") %}
+{% set xts_expect_reboot = xts_expect_reboot|default(true) %}

--- a/lava_test_plans/testcases/master/template-android-xts.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-android-xts.yaml.jinja2
@@ -1,0 +1,30 @@
+{% extends "testcases/master/template-master.jinja2" %}
+
+{## This template is not for generic use, please consider ##}
+{## to use the template-android-cts.yaml.jinja2 and ## }
+{## template-android-vts.yaml.jinja2 ##}
+
+{% set xts_result_format = xts_result_format|default("aggregated") %}
+{% set xts_test_definition_path = xts_test_definition_path|default("automated/android/noninteractive-tradefed/tradefed.yaml") %}
+
+{% block metadata %}
+  {{ super() }}
+  {{xts_metadata_prefix}}-url: "{{xts_test_url}}/{{xts_pkg_name}}"
+  {{xts_metadata_prefix}}-manifest: "{{xts_test_url}}/pinned-manifest.xml"
+  {{xts_metadata_prefix}}-version: "{{xts_version}}"
+{% endblock metadata %}
+
+{% block test_target %}
+  {{ super() }}
+    - repository: {{TEST_DEFINITIONS_REPOSITORY}}
+      from: git
+      path: {{xts_test_definition_path}}
+      params:
+        TEST_PARAMS: {% block xts_test_params %}{{xts_test_params}}{% endblock xts_test_params %}
+        TEST_URL: "{{xts_test_url}}/{{xts_pkg_name}}"
+        TEST_PATH: "{{xts_test_path}}"
+        RESULTS_FORMAT: "{{xts_result_format}}"
+        ANDROID_VERSION: "{{ANDROID_VERSION}}"
+        TEST_REBOOT_EXPECTED: "{{xts_expect_reboot}}"
+      name: "{{xts_test_suite_name}}"
+{% endblock test_target %}


### PR DESCRIPTION
The cts vts  templates added here are generic templates which will be used by many other projects as well
