### PR TITLE
include:fastboot: drop the rootfs check for ptable partition

### DIFF
--- a/lava_test_plans/fastboot.jinja2
+++ b/lava_test_plans/fastboot.jinja2
@@ -9,13 +9,11 @@
     docker:
       image: {{DOCKER_IMAGE_DEPLOY}}
     images:
-{% if rootfs == true %}
 {% if ptable == true %}
       ptable:
         url: downloads://{{DOCKER_PTABLE_FILE}}
 {% if reboot_reset == true %}
         reboot: hard-reset
-{% endif %}
 {% endif %}
 {% endif %}
 {% if boot == true and BOOT_LABEL != "kernel" %}

--- a/lava_test_plans/include/fastboot.jinja2
+++ b/lava_test_plans/include/fastboot.jinja2
@@ -68,7 +68,6 @@ reboot_to_fastboot: {{ reboot_to_fastboot }}
       minutes: {{ target_deploy_timeout }}
     to: {{ DEPLOY_TARGET }}
     images:
-{% if rootfs == true %}
 {% if ptable == true %}
       {{ PTABLE_LABEL }}:
         url: {{PTABLE_URL}}
@@ -77,7 +76,6 @@ reboot_to_fastboot: {{ reboot_to_fastboot }}
 {% endif %}
 {% if reboot_reset == true and DEPLOY_TARGET == "fastboot" %}
         reboot: hard-reset
-{% endif %}
 {% endif %}
 {% endif %}
 {% if boot == true and partition_boot_with_postprocess == true %}

--- a/lava_test_plans/projects/lkft/fastboot.jinja2
+++ b/lava_test_plans/projects/lkft/fastboot.jinja2
@@ -25,13 +25,11 @@
     docker:
       image: {{DOCKER_IMAGE_DEPLOY}}
     images:
-{% if rootfs == true %}
 {% if ptable == true %}
       {{ PTABLE_LABEL }}:
         url: downloads://{{DOCKER_PTABLE_FILE}}
 {% if reboot_reset == true %}
         reboot: hard-reset
-{% endif %}
 {% endif %}
 {% endif %}
 {% if boot == true and BOOT_LABEL != "kernel" or BOOT_LABEL_OVERRIDE == true %}

--- a/lava_test_plans/projects/lt-qcom/fastboot.jinja2
+++ b/lava_test_plans/projects/lt-qcom/fastboot.jinja2
@@ -143,13 +143,11 @@ protocols:
     to: fastboot
     namespace: target
     images:
-{% if rootfs == true %}
 {% if ptable == true %}
       "{{ PTABLE_LABEL }}":
         url: lxc:///{{ LXC_PTABLE_FILE }}
 {% if reboot_reset == true %}
         reboot: hard-reset
-{% endif %}
 {% endif %}
 {% endif %}
       boot:


### PR DESCRIPTION
as there is the case like android that rootfs is not required, but ptable is required