### PR TITLE
lkft-android: set default group to lkft

### DIFF
--- a/lava_test_plans/projects/lkft-android/fastboot.jinja2
+++ b/lava_test_plans/projects/lkft-android/fastboot.jinja2
@@ -5,6 +5,9 @@
 {% set target_deploy_timeout = target_deploy_timeout |default(35) %}
 {% set deploy_fastboot_timeout = deploy_fastboot_timeout|default(10) %}
 
+{% set LAVA_JOB_VISIBILITY = LAVA_JOB_VISIBILITY|default("group") %}
+{% set LAVA_JOB_VISIBILITY_GROUPS = LAVA_JOB_VISIBILITY_GROUPS|default(["lkft"]) %}
+
 {# force all the lkft-android jobs to be run with the docker method #}
 {% set USE_DOCKER_IMAGE_TEST_TARGET = true %}
 


### PR DESCRIPTION
as the lkft-android project needs to have some
secrets set in the lava job for the cts/vts test to upload test results logs to the archive site,
which needs the job to be not public by default,
here set to the "lkft" lava group by default.