### PR TITLE
master: fix problem when only one group specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Lines starting with *#* are omited. Variables can also be set using
  * *OS_INFO*: used in test job name
  * *LAVA_JOB_PRIORITY*: priority of the LAVA job, used by LAVA scheduler
  * *LAVA_JOB_VISIBILITY*: defaults to *public*. This block can be used to restrict job visibility to user or group.
+ * *LAVA_JOB_VISIBILITY_GROUPS*: variable should contain groups required by job. Formtatting is important and this variable should be
+ formatted comma separated list. Example: group1, group2. In case of using just one group, end string with comma. Example:
+ group1,
  * *AUTO_LOGIN_*: default *PROMPT='login:', *USERNAME='root' and *PASSWORD=''.
  * *BOOT_LABEL*: default BOOT_LABEL='boot'.
  * *TAGS*: variable should contain tags required by job. Formtatting is important and this variable should be

--- a/test/test_lava_job_visibility.py
+++ b/test/test_lava_job_visibility.py
@@ -11,11 +11,14 @@ test_lava_validity = "" if os.getenv("SKIP_TEST_LAVA_VALIDITY") else "--test-lav
 
 devices = ['hi960-hikey', 'x15', 'qemu_arm64']
 testcase = 'ltp-syscalls.yaml'
-variable_input_file = "test/variables-visibility.ini"
+variable_input_files = [
+                        "test/variables-visibility.ini",
+                        "test/variables-visibility-one-group.ini",
+                       ]
 tests = []
 for device in devices:
-    tests.append((variable_input_file, device, testcase))
-
+    for variable_file in variable_input_files:
+        tests.append((variable_file, device, testcase))
 
 @pytest.mark.parametrize("param", tests)
 def test_call_lava_visibility_group_testcase(param):

--- a/test/variables-visibility-one-group.ini
+++ b/test/variables-visibility-one-group.ini
@@ -1,0 +1,25 @@
+TAGS=tag1
+BUILD_URL=build-url
+BOOT_URL=boot-url
+SYSTEM_URL=system-url
+DEVICE_TYPE=device-type
+SKIPGEN_KERNEL_VERSION=skipgen-kernel-version
+LAVA_JOB_PRIORITY=99
+TDEFINITIONS_REVISION=tdefinitions-revision
+KERNEL_URL=variable-value
+MODULES_URL=variable-value
+DTB_URL=variable-value
+ROOTFS_URL=variable-value
+DEPLOY_OS=variable-value
+DOCKER_ROOTFS_FILE=docker-rootfs-file
+BOOT_OS_PROMPT=variable-value
+SMOKE_TESTS=variable-value
+PM_QA_TESTS=pm-qa-tests
+DOCKER_BOOT_FILE=docker-boot
+DOCKER_PTABLE_FILE=docker-boot
+QA_SERVER_PROJECT=qa-server-project
+# misc variables
+LAVA_TEST_NAME_SUFFIX=
+TEST_DEFINITIONS_REPOSITORY=https://github.com/Linaro/test-definitions.git
+LAVA_JOB_VISIBILITY=group
+LAVA_JOB_VISIBILITY_GROUPS=group1,


### PR DESCRIPTION
when there is only one group specified in the variables.ini file, LAVA_JOB_VISIBILITY_GROUPS will be read as
as string, and will not be listed for the visibility items.

This change fixes the problem by adding it as a single lava group for the job visibility item when LAVA_JOB_VISIBILITY_GROUPS is not a sequence.