### PR TITLE
lkft-android: add support for the hikey960 device

### DIFF
--- a/lava_test_plans/devices/hi960-hikey
+++ b/lava_test_plans/devices/hi960-hikey
@@ -1,16 +1,16 @@
 {% set PROJECT = PROJECT|default("") %}
 {% extends PROJECT+"fastboot.jinja2" %}
 
-{% set auto_login = false %}
-{% set boot_method = "grub" %}
-{% set pre_boot_command = true %}
-{% set pre_os_command = true %}
-{% set pre_power_command = true %}
-{% set post_boot_command = true %}
-{% set ptable = false %}
-{% set reboot_reset = true %}
-{% set rootfs = true %}
-{% set rootfs_label = 'system' %}
+{% set auto_login = auto_login|default(false) %}
+{% set boot_method = boot_method|default("grub") %}
+{% set pre_boot_command = pre_boot_command|default(true) %}
+{% set pre_os_command = pre_os_command|default(true) %}
+{% set pre_power_command = pre_power_command|default(true) %}
+{% set post_boot_command = post_boot_command|default(true) %}
+{% set ptable = ptable|default(false) %}
+{% set reboot_reset = reboot_reset|default(true) %}
+{% set rootfs = rootfs|default(true) %}
+{% set rootfs_label = rootfs_label|default('system') %}
 
 {% block device_type %}hi960-hikey{% endblock %}
 

--- a/lava_test_plans/projects/lkft-android/devices/hi960-hikey
+++ b/lava_test_plans/projects/lkft-android/devices/hi960-hikey
@@ -1,0 +1,37 @@
+{% extends "devices/hi960-hikey" %}
+
+{% set TAGS = TAGS|default(["old-firmware"]) %}
+
+{# to avoid overriding by the one definied in testcases #}
+{# like the one defined in testcases/boot.yaml is set to true by default #}
+{% set auto_login = false %}
+{% set boot_method = "fastboot" %}
+{% set pre_boot_command = false %}
+{% set pre_os_command = false %}
+{% set pre_power_command = false %}
+{% set post_boot_command = false %}
+{% set rootfs = false %}
+
+{% set BOOT_OS_PROMPT = BOOT_OS_PROMPT|default(["console:/"]) %}
+{% set FASTBOOT_COMMANDS = FASTBOOT_COMMANDS|default(["format cache", "reboot bootloader"]) %}}
+
+{% set ptable = true %}
+{% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("prm_ptable.img") %}
+{% set PTABLE_URL = PRM_PTABLE_URL|default("http://testdata.linaro.org/lkft/aosp-stable/android/lkft/lkft-aosp-master-hikey960/555/prm_ptable.img") %}
+{% set DOCKER_PTABLE_FILE = DOCKER_PRM_PTABLE_FILE|default("prm_ptable.img") %}
+
+{% set partition_super = true %}
+{% set partition_userdata = true %}
+
+{% if TUXSUITE_BAKE_VENDOR_DOWNLOAD_URL is defined %}
+{% set download_postprocess_required = true %}
+{% set partition_boot_with_postprocess = false %}
+{% set partition_super_with_postprocess = false %}
+{% set partition_system_with_postprocess = false %}
+{% set partition_vendor_with_postprocess = false %}
+{% set partition_userdata_with_postprocess = false %}
+{% endif%}
+
+{# override the boot_commands block defined in "devices/hi960-hikey" #}
+{% block boot_commands %}
+{% endblock boot_commands %}


### PR DESCRIPTION
so that it's possible to test the lkft-android jobs with the hikey960 devices.