### PR TITLE
projects: lkft: devices: db410c: add a default BOOT_URL

### DIFF
--- a/lava_test_plans/projects/lkft/devices/dragonboard-410c
+++ b/lava_test_plans/projects/lkft/devices/dragonboard-410c
@@ -1,5 +1,6 @@
 {% extends "devices/dragonboard-410c" %}
 
+{% set BOOT_URL = BOOT_URL|default("http://images.validation.linaro.org/releases.linaro.org/96boards/dragonboard410c/linaro/debian/18.01/boot-linaro-buster-dragonboard-410c-359.img.gz") %}
 {% set MODULES_URL_COMP = MODULES_URL_COMP|default("xz") %}
 {% set OVERLAY_KSELFTEST_URL_FORMAT = OVERLAY_KSELFTEST_URL_FORMAT|default("tar") %}
 {% set OVERLAY_KSELFTEST_URL_COMP = OVERLAY_KSELFTEST_URL_COMP|default("xz") %}


### PR DESCRIPTION
Point the default BOOT_URL to the health-check's BOOT_URL that the LAB are using.