### PR TITLE
testcases: kselftest-short-run-2: fix typo filesystems.epoll

### DIFF
--- a/lava_test_plans/testcases/kselftest-short-run-2.yaml
+++ b/lava_test_plans/testcases/kselftest-short-run-2.yaml
@@ -1,5 +1,5 @@
 {% extends "master/template-kselftest.yaml.jinja2" %}
 
 {% set guestfs_size = 1024 %}
-{% set testnames = ['efivarfs', 'filesystems',  'filesystems.binderfs', 'filesytems.epoll', 'firmware', 'fpu', 'ftrace', 'futex'] %}
+{% set testnames = ['efivarfs', 'filesystems',  'filesystems.binderfs', 'filesystems.epoll', 'firmware', 'fpu', 'ftrace', 'futex'] %}
 {% set test_timeout = 40 %}


### PR DESCRIPTION
Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>