### PR TITLE
testcases: android-vts: add testcases for the full vts test plan

### DIFF
--- a/lava_test_plans/testcases/android-vts-FastbootVerifyUserspaceTest.yaml
+++ b/lava_test_plans/testcases/android-vts-FastbootVerifyUserspaceTest.yaml
@@ -1,0 +1,6 @@
+{% extends "testcases/master/template-android-vts.yaml.jinja2" %}
+
+{% set test_timeout = 60 %}
+{% set test_name = "vts-FastbootVerifyUserspaceTest" %}
+
+{% block xts_test_params %}vts -m FastbootVerifyUserspaceTest{% endblock xts_test_params %}

--- a/lava_test_plans/testcases/android-vts-VtsHalAudioV4_0TargetTest.yaml
+++ b/lava_test_plans/testcases/android-vts-VtsHalAudioV4_0TargetTest.yaml
@@ -1,0 +1,6 @@
+{% extends "testcases/master/template-android-vts.yaml.jinja2" %}
+
+{% set test_timeout = 60 %}
+{% set test_name = "vts-VtsHalAudioV4_0TargetTest" %}
+
+{% block xts_test_params %}vts -m VtsHalAudioV4_0TargetTest{% endblock xts_test_params %}

--- a/lava_test_plans/testcases/android-vts-part0.yaml
+++ b/lava_test_plans/testcases/android-vts-part0.yaml
@@ -1,0 +1,6 @@
+{% extends "testcases/master/template-android-vts.yaml.jinja2" %}
+
+{% set test_timeout = 360 %}
+{% set test_name = "vts-part0" %}
+
+{% block xts_test_params %}vts --exclude-filter FastbootVerifyUserspaceTest --exclude-filter VtsHalAudioV4_0TargetTest{% endblock xts_test_params %}


### PR DESCRIPTION
with the VtsHalAudioV4_0TargetTest and FastbootVerifyUserspaceTest modules run in separate jobs.

refer to the existing android-vts-kernel-v8a.yaml testcase