### PR TITLE
testcases: master: template-kselftest: rename test_name

### DIFF
--- a/lava_test_plans/testcases/master/template-kselftest.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-kselftest.yaml.jinja2
@@ -4,7 +4,7 @@
 {%- if vsyscall_mode is defined %}
   {%- set vsyscall_suffix = "-vsyscall-mode-"+vsyscall_mode %}
 {%- endif -%}
-{% set test_name = "kselftests-" + testnames|join('-') + vsyscall_suffix %}
+{% set test_name = "kselftest-" + testnames|join('-') + vsyscall_suffix %}
 {% set use_context = true %}
 {% if vsyscall_mode is defined %}
 {% set extra_kernel_args = 'vsyscall={{vsyscall_mode}} ' + extra_kernel_args|default("") %}


### PR DESCRIPTION
Make the test-name the same as the testcase name, to remove the mismatch in testcases name an test_name.

Reported-by: Senthil Kumaran S <senthil.kumaran@linaro.org>