### PR TITLE
testcases: master: template-kselftest: set default revision to '.'

### DIFF
--- a/lava_test_plans/testcases/master/template-kselftest.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-kselftest.yaml.jinja2
@@ -37,7 +37,9 @@
 {% for testname in testnames %}
     - repository: {{ TEST_DEFINITIONS_REPOSITORY }}
       from: git
-      revision: '{{ TDEFINITIONS_REVISION }}'
+{% if TDEFINITIONS_REVISION is defined %}
+      revision: '{{ TDEFINITIONS_REVISION}}'
+{% endif %}
       path: automated/linux/kselftest/kselftest.yaml
       name: kselftest-{{testname|replace('.', '-')}}{{vsyscall_suffix}}
       parameters:


### PR DESCRIPTION
Default the revision to '.' if TDEFINITIONS_REVISION is not set.

Reported-by: Senthil Kumaran S <senthil.kumaran@linaro.org>