### PR TITLE
testcases: master: template-master: make EXTRA_KERNEL_ARGS an externa…

### DIFF
--- a/lava_test_plans/devices/bcm2711-rpi-4-b
+++ b/lava_test_plans/devices/bcm2711-rpi-4-b
@@ -5,7 +5,7 @@
 
 {% set auto_login = true %}
 {% set boot_method = "u-boot" %}
-{% set extra_kernel_args = '8250.nr_uarts=1 cma=64M rootwait' + extra_kernel_args|default("") %}
+{% set EXTRA_KERNEL_ARGS = '8250.nr_uarts=1 cma=64M rootwait' + EXTRA_KERNEL_ARGS|default("") %}
 {% set rootfs_label="nfsrootfs" %}
 {% set use_context = true %}
 

--- a/lava_test_plans/devices/nxp-ls2088
+++ b/lava_test_plans/devices/nxp-ls2088
@@ -5,7 +5,7 @@
 
 {% set auto_login = true %}
 {% set boot_method = "u-boot" %}
-{% set extra_kernel_args = 'arm-smmu-mod.disable_bypass=n arm-smmu.disable_bypass=n ' + extra_kernel_args|default("") %}
+{% set EXTRA_KERNEL_ARGS = 'arm-smmu-mod.disable_bypass=n arm-smmu.disable_bypass=n ' + EXTRA_KERNEL_ARGS|default("") %}
 {% set rootfs_label="nfsrootfs" %}
 {% set use_context = true %}
 

--- a/lava_test_plans/projects/lkft/devices/juno-r2
+++ b/lava_test_plans/projects/lkft/devices/juno-r2
@@ -10,7 +10,7 @@
 {% set OVERLAY_URL_COMP = OVERLAY_URL_COMP|default("xz") %}
 {% set ROOTFS_URL_FORMAT = ROOTFS_URL_FORMAT|default("tar") %}
 
-{% set extra_kernel_args = 'default_hugepagesz=2M hugepages=256 ' + extra_kernel_args|default("") %}
+{% set EXTRA_KERNEL_ARGS = 'default_hugepagesz=2M hugepages=256 ' + EXTRA_KERNEL_ARGS|default("") %}
 
 {% block context %}
   {{ super() }}

--- a/lava_test_plans/testcases/master/template-kselftest.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-kselftest.yaml.jinja2
@@ -7,7 +7,7 @@
 {% set test_name = "kselftest-" + testnames|join('-') + vsyscall_suffix %}
 {% set use_context = true %}
 {% if vsyscall_mode is defined %}
-{% set extra_kernel_args = 'vsyscall={{vsyscall_mode}} ' + extra_kernel_args|default("") %}
+{% set EXTRA_KERNEL_ARGS = 'vsyscall={{vsyscall_mode}} ' + EXTRA_KERNEL_ARGS|default("") %}
 {% endif %}
 
 {% set KSELFTEST_PATH = KSELFTEST_PATH|default('/opt/kselftests/default-in-kernel') %}

--- a/lava_test_plans/testcases/master/template-kvm-unit-tests.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-kvm-unit-tests.yaml.jinja2
@@ -2,7 +2,7 @@
 
 {% set use_context = true %}
 
-{% set extra_kernel_args = ' kvm.enable_vmware_backdoor=1 kvm.force_emulation_prefix=1 ' + extra_kernel_args|default("") %}
+{% set EXTRA_KERNEL_ARGS = ' kvm.enable_vmware_backdoor=1 kvm.force_emulation_prefix=1 ' + EXTRA_KERNEL_ARGS|default("") %}
 
 {% set test_timeout = 25 %}
 {% block metadata %}

--- a/lava_test_plans/testcases/master/template-master.jinja2
+++ b/lava_test_plans/testcases/master/template-master.jinja2
@@ -12,7 +12,7 @@
 
 {% block context %}
 {{ super() }}
-  {%- if extra_kernel_args is defined %}
-  extra_kernel_args: '{{extra_kernel_args}}'
+  {%- if EXTRA_KERNEL_ARGS is defined %}
+  extra_kernel_args: '{{EXTRA_KERNEL_ARGS}}'
   {%- endif %}
 {% endblock context %}


### PR DESCRIPTION
…l variable

Tried to change the extra_kernel_args in the LAVA job for a specific job, this could be done by setting the 'extra_kernel_args' variable. In order to set an externa input variable this should be done from upercase variables.
Change the 'extra_kernel_args' variable to be 'EXTRA_KERNEL_ARGS'.