### PR TITLE
Default testcases to use lava signal kmsg

### DIFF
--- a/lava_test_plans/testcases/master/template-kselftest.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-kselftest.yaml.jinja2
@@ -12,6 +12,8 @@
 
 {% set KSELFTEST_PATH = KSELFTEST_PATH|default('/opt/kselftests/default-in-kernel') %}
 
+{% set test_target_redirect_to_kmsg = test_target_redirect_to_kmsg|default(true) %}
+
 {% extends "testcases/master/template-master.jinja2" %}
 
 {% block metadata %}
@@ -41,6 +43,9 @@
       from: git
 {% if TDEFINITIONS_REVISION is defined %}
       revision: '{{ TDEFINITIONS_REVISION}}'
+{% endif %}
+{% if test_target_redirect_to_kmsg is defined and test_target_redirect_to_kmsg %}
+      lava-signal: kmsg
 {% endif %}
       path: automated/linux/kselftest/kselftest.yaml
       name: kselftest-{{testname|replace('.', '-')}}{{vsyscall_suffix}}

--- a/lava_test_plans/testcases/master/template-network-basic-tests.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-network-basic-tests.yaml.jinja2
@@ -1,7 +1,6 @@
 {% extends "testcases/master/template-test.jinja2" %}
 
 {% set test_timeout = 25 %}
-{% set test_target_redirect_to_kmsg = true %}
 {% set test_name = "network-basic-tests" %}
 {% set test_path_file = 'automated/linux/network-basic/network-basic.yaml' %}
 

--- a/lava_test_plans/testcases/master/template-sysbench.yaml.jinja2
+++ b/lava_test_plans/testcases/master/template-sysbench.yaml.jinja2
@@ -5,6 +5,7 @@
 {% set LAVA_TEST_NAME_SUFFIX = LAVA_TEST_NAME_SUFFIX|default("") %}
 
 {% set test_name = "sysbench-" + testnames|join('-') + LAVA_TEST_NAME_SUFFIX %}
+{% set test_target_redirect_to_kmsg = test_target_redirect_to_kmsg|default(true) %}
 
 {% block test_target %}
   {{ super() }}
@@ -13,6 +14,9 @@
 {% for testname in testnames %}
     - repository: {{ TEST_DEFINITIONS_REPOSITORY }}
       from: git
+{% if test_target_redirect_to_kmsg is defined and test_target_redirect_to_kmsg %}
+      lava-signal: kmsg
+{% endif %}
       path: automated/linux/sysbench/sysbench.yaml
       parameters:
         SKIP_INSTALL: 'false'

--- a/lava_test_plans/testcases/master/template-test.jinja2
+++ b/lava_test_plans/testcases/master/template-test.jinja2
@@ -1,5 +1,7 @@
 {% extends "testcases/master/template-master.jinja2" %}
 
+{% set test_target_redirect_to_kmsg = test_target_redirect_to_kmsg|default(true) %}
+
 {% block test_target %}
   {{ super() }}
     - repository: {{ TEST_DEFINITIONS_REPOSITORY }}

--- a/lava_test_plans/testcases/v4l2-compliance.yaml
+++ b/lava_test_plans/testcases/v4l2-compliance.yaml
@@ -2,7 +2,6 @@
 
 {% set test_timeout = 25 %}
 {% set video_driver = "vivid.ko" %}
-{% set test_target_redirect_to_kmsg = true %}
 
 {% set test_name = test_name | default("v4l2-compliance") %}
 {% set test_path_file = 'automated/linux/v4l2/v4l2-compliance.yaml' %}


### PR DESCRIPTION
Change so default in testcases/master/template-test.jinja2 will be so 'test_target_redirect_to_kmsg = true' if nothing else is specified.
any test exept tests inside docker work with redirecting the test output to kmsg.