### PR TITLE
testcases: template-master: extra_kernel_args: set systemd log_level

### DIFF
--- a/lava_test_plans/testcases/master/template-master.jinja2
+++ b/lava_test_plans/testcases/master/template-master.jinja2
@@ -4,6 +4,7 @@
 {% set BUILD_NUMBER = BUILD_NUMBER|default("") %}
 {% set KERNEL_BRANCH = KERNEL_BRANCH|default("unknown") %}
 {% set OS_INFO = OS_INFO|default("") %}
+{% set EXTRA_KERNEL_ARGS = ' systemd.log_level=warning ' + EXTRA_KERNEL_ARGS|default("") %}
 
 {# with the BUILD_NUMBER in the middle, it's possible to get #}
 {# the sub job name(which is the test_name here) #}


### PR DESCRIPTION
Always set systemd's log_level to 'warning', if the user want more logs for debug purpuses then that can be enabled by setting the EXTRA_KERNEL_ARGS='systemd.log_level=debug' and that will override it.