### PR TITLE
testcases: additional mmtests

### DIFF
--- a/lava_test_plans/testcases/mmtests-io-fsmark-small-file-stream.yaml
+++ b/lava_test_plans/testcases/mmtests-io-fsmark-small-file-stream.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/master/template-mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-scheduler-schbench.yaml
+++ b/lava_test_plans/testcases/mmtests-scheduler-schbench.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/master/template-mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-scheduler-sysbench-thread.yaml
+++ b/lava_test_plans/testcases/mmtests-scheduler-sysbench-thread.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/master/template-mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-usemem.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-usemem.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/master/template-mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}


### PR DESCRIPTION
New test cases, which use MMTests framework:
- mmtests-io-fsmark-small-file-stream
- mmtests-scheduler-schbench
- mmtests-scheduler-sysbench-thread
- mmtests-workload-usemem