### PR TITLE
Andorid: changes on test suite name for tuxsuite

### DIFF
--- a/lava_test_plans/testcases/android-vts-kernel-v7a.yaml
+++ b/lava_test_plans/testcases/android-vts-kernel-v7a.yaml
@@ -1,6 +1,6 @@
 {% extends "testcases/templates/android-vts.yaml.jinja2" %}
 
 {% set test_timeout = 480 %}
-{% set test_name = "vts-kernel-armeabi-v7a" %}
+{% set test_name = "android-vts-kernel-v7a" %}
 
 {% block xts_test_params %}vts-kernel --abi armeabi-v7a{% endblock xts_test_params %}

--- a/lava_test_plans/testcases/android-vts-kernel-v8a.yaml
+++ b/lava_test_plans/testcases/android-vts-kernel-v8a.yaml
@@ -1,6 +1,6 @@
 {% extends "testcases/templates/android-vts.yaml.jinja2" %}
 
 {% set test_timeout = 480 %}
-{% set test_name = "vts-kernel-arm64-v8a" %}
+{% set test_name = "android-vts-kernel-v8a" %}
 
 {% block xts_test_params %}vts-kernel --abi arm64-v8a{% endblock xts_test_params %}


### PR DESCRIPTION
fix the test_name value and testcase file name not the same problem,
and make the xts test suite name overridable for flexibility