### PR TITLE
projects: lkft: fastboot: enable docker during boot section

### DIFF
--- a/lava_test_plans/projects/lkft/fastboot.jinja2
+++ b/lava_test_plans/projects/lkft/fastboot.jinja2
@@ -7,6 +7,7 @@
 {% set BOOT_LABEL_OVERRIDE = BOOT_LABEL_OVERRIDE|default(false) %}
 {% set DEPLOY_TARGET = DEPLOY_TARGET|default("downloads") %}
 {% set DOCKER_IMAGE_DEPLOY = DOCKER_IMAGE_DEPLOY|default("linaro/kir:master") %}
+{% set DOCKER_IMAGE_BOOT = DOCKER_IMAGE_BOOT|default("linaro/kir:master") %}
 {% set DOCKER_IMAGE_POSTPROCESS = DOCKER_IMAGE_POSTPROCESS|default("linaro/kir:master") %}
 {% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("ptable-linux-8g.img") %}
 {% set DOCKER_BOOT_FILE = DOCKER_BOOT_FILE|default("boot.img") %}


### PR DESCRIPTION
Enable docker during the boot section on the fastboot devices. This makes it easier to kill the docker container when a fastboot connection hangs.