### PR TITLE
testcases: add more mmtests

### DIFF
--- a/lava_test_plans/testcases/mmtests-workload-aim9-disk.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-aim9-disk.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-stressng-af-alg.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-stressng-af-alg.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-stressng-bad-altstack.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-stressng-bad-altstack.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-stressng-fork.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-stressng-fork.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-stressng-getdent.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-stressng-getdent.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-stressng-madvise.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-stressng-madvise.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-stressng-vm-splice.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-stressng-vm-splice.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-stressng-zombie.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-stressng-zombie.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-will-it-scale-io-processes.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-will-it-scale-io-processes.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-will-it-scale-io-threads.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-will-it-scale-io-threads.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-will-it-scale-pf-processes.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-will-it-scale-pf-processes.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-will-it-scale-pf-threads.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-will-it-scale-pf-threads.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-will-it-scale-sys-processes.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-will-it-scale-sys-processes.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}

--- a/lava_test_plans/testcases/mmtests-workload-will-it-scale-sys-threads.yaml
+++ b/lava_test_plans/testcases/mmtests-workload-will-it-scale-sys-threads.yaml
@@ -1,0 +1,5 @@
+{% extends "testcases/templates/mmtests.yaml.jinja2" %}
+
+{% set config_file = 'configs/' + self._TemplateReference__context.name|replace('mmtests', 'config')|replace('.yaml', '') %}
+{% set mmtest_iterations = 10 %}
+{% set test_timeout = 90 %}


### PR DESCRIPTION
Added a few more sub-tests from the mmtests framework.
- mmtests-workload-aim9-disk.yaml
- mmtests-workload-stressng-af-alg.yaml
- mmtests-workload-stressng-bad-altstack.yaml
- mmtests-workload-stressng-fork.yaml
- mmtests-workload-stressng-getdent.yaml
- mmtests-workload-stressng-madvise.yaml
- mmtests-workload-stressng-vm-splice.yaml
- mmtests-workload-stressng-zombie.yaml
- mmtests-workload-will-it-scale-io-processes.yaml
- mmtests-workload-will-it-scale-io-threads.yaml
- mmtests-workload-will-it-scale-pf-processes.yaml
- mmtests-workload-will-it-scale-pf-threads.yaml
- mmtests-workload-will-it-scale-sys-processes.yaml
- mmtests-workload-will-it-scale-sys-threads.yaml