### PR TITLE
projects: lkft: devices: if DEPLOY_OS is debian set ROOTFS_URL_COMP t…

### DIFF
--- a/lava_test_plans/projects/lkft/devices/qemu_arm64
+++ b/lava_test_plans/projects/lkft/devices/qemu_arm64
@@ -1,3 +1,7 @@
+{% if DEPLOY_OS == "debian" %}
+{% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("xz") %}
+{% endif %}
+
 {% extends "devices/qemu_arm64" %}
 
 {% set ROOTFS_URL_FORMAT = ROOTFS_URL_FORMAT|default("ext4") %}

--- a/lava_test_plans/projects/lkft/devices/qemu_i386
+++ b/lava_test_plans/projects/lkft/devices/qemu_i386
@@ -1,3 +1,7 @@
+{% if DEPLOY_OS == "debian" %}
+{% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("xz") %}
+{% endif %}
+
 {% extends "devices/qemu_i386" %}
 
 {% set ROOTFS_URL_FORMAT = ROOTFS_URL_FORMAT|default("ext4") %}

--- a/lava_test_plans/projects/lkft/devices/qemu_x86_64
+++ b/lava_test_plans/projects/lkft/devices/qemu_x86_64
@@ -1,3 +1,7 @@
+{% if DEPLOY_OS == "debian" %}
+{% set ROOTFS_URL_COMP = ROOTFS_URL_COMP|default("xz") %}
+{% endif %}
+
 {% extends "devices/qemu_x86_64" %}
 
 {% set ROOTFS_URL_FORMAT = ROOTFS_URL_FORMAT|default("ext4") %}


### PR DESCRIPTION
…o 'xz'

This has been done for the other devices, and should have been done for qemu_* too.
If debian rootfs default the compression to 'xz'.