### PR TITLE
Fastboot add ramdisk option

### DIFF
--- a/lava_test_plans/include/fastboot.jinja2
+++ b/lava_test_plans/include/fastboot.jinja2
@@ -10,6 +10,7 @@
 {% set reboot_to_fastboot = reboot_to_fastboot|default("false") %}
 {% set boot = boot|default(true) %}
 {% set BOOT_LABEL = BOOT_LABEL|default("boot") %}
+{% set ramdisk = ramdisk|default(false) %}
 {% set rootfs = rootfs|default(true) %}
 {% set rootfs_label = rootfs_label|default("rootfs") %}
 {% set apply_overlay = apply_overlay|default("rootfs") %}
@@ -134,6 +135,16 @@ reboot_to_fastboot: {{ reboot_to_fastboot }}
 {% endif %}
 {% if MODULES_URL_COMP is defined %}
         compression: {{MODULES_URL_COMP}}
+{% endif %}
+{% endif %}
+{% if ramdisk == true %}
+      ramdisk:
+        url: {{RAMDISK_URL}}
+{% if RAMDISK_URL_FORMAT is defined %}
+        format: {{RAMDISK_URL_FORMAT}}
+{% endif %}
+{% if RAMDISK_URL_COMP is defined %}
+        compression: {{RAMDISK_URL_COMP}}
 {% endif %}
 {% endif %}
 {% if rootfs == true %}

--- a/lava_test_plans/projects/lkft/devices/dragonboard-845c
+++ b/lava_test_plans/projects/lkft/devices/dragonboard-845c
@@ -4,6 +4,7 @@
 
 {% extends "devices/dragonboard-845c" %}
 
+{% set ramdisk = ramdisk|default(true) %}
 {% set BOOT_LABEL = "kernel" %}
 {% set BOOT_LABEL_OVERRIDE = true %}
 {% set DOCKER_PTABLE_FILE = DOCKER_PTABLE_FILE|default("gpt_both0.bin") %}
@@ -15,4 +16,5 @@
 {% set OVERLAY_PERF_URL_COMP = OVERLAY_PERF_URL_COMP|default("xz") %}
 {% set OVERLAY_URL_FORMAT = OVERLAY_URL_FORMAT|default("tar") %}
 {% set OVERLAY_URL_COMP = OVERLAY_URL_COMP|default("xz") %}
+{% set RAMDISK_URL = RAMDISK_URL|default("https://snapshots.linaro.org/member-builds/qcomlt/boards/qcom-armv8a/openembedded/master/56008/rpb/initramfs-rootfs-image-qcom-armv8a.rootfs-20240118001247-92260.cpio.gz") %}
 {% set ROOTFS_URL_FORMAT = ROOTFS_URL_FORMAT|default("ext4") %}


### PR DESCRIPTION
Make it possible to download a ramdisk_url, in the db845c case its a initrd that will be used in kir.
the initramfs.cpio.gz file together with the modules creates the initrd.cpio.gz file that makes it possible to load modules that isn't built into the kernel. Which happens when a defconfig kernel are built.