### PR TITLE
testcases: template: kvm-unit-tests: rockpi4: set SMP to false

### DIFF
--- a/lava_test_plans/testcases/templates/kvm-unit-tests.yaml.jinja2
+++ b/lava_test_plans/testcases/templates/kvm-unit-tests.yaml.jinja2
@@ -17,6 +17,6 @@
   {{ super() }}
       parameters:
         SKIP_INSTALL: 'true'
-        SMP: {% if DEVICE_TYPE == "juno-r2" %}'false'{% else %}'true'{% endif %}
+        SMP: {% if DEVICE_TYPE == "juno-r2" or DEVICE_TYPE == "rk3399-rock-pi-4b" %}'false'{% else %}'true'{% endif %}
         GIT_REF: "{{KVM_UNIT_TESTS_REVISION | default('a3d5d6b9333e10898852b96311c3d3db0baf5a4e')}}"
 {% endblock test_target %}


### PR DESCRIPTION
Since rockpi4 has a big.LITTLE hetrogeneous CPU cluster, the kvm-unit-tests suite need to turn off SMP.

Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>