### PR TITLE
project: lkft: devices: db845c: disable 'lava-signal: kmsg'

### DIFF
--- a/lava_test_plans/projects/lkft/devices/dragonboard-845c
+++ b/lava_test_plans/projects/lkft/devices/dragonboard-845c
@@ -4,6 +4,8 @@
 
 {% extends "devices/dragonboard-845c" %}
 
+{% set test_target_redirect_to_kmsg = false %}
+
 {% set ramdisk = ramdisk|default(true) %}
 {% set BOOT_LABEL = "kernel" %}
 {% set BOOT_LABEL_OVERRIDE = true %}


### PR DESCRIPTION
This is a workaround until a proper solution is fixed for why LAVA jobs on db845c ends up with 'Invalid TESTCASE signal'.

Suggested-by: Chase Qi <chase.qi@linaro.org>