### PR TITLE
testcases: ltp-short-run-2: drop fsx suite

### DIFF
--- a/lava_test_plans/projects/lkft/devices/variables/bcm2711-rpi-4-b.yaml
+++ b/lava_test_plans/projects/lkft/devices/variables/bcm2711-rpi-4-b.yaml
@@ -1,7 +1,6 @@
 DEVICE_TYPE: bcm2711-rpi-4-b
 KERNEL_URL: unknown
 DTB_URL: unknown
-BOOT_URL: unknown
 MODULES_URL: unknown
 ROOTFS_URL: unknown
 LAVA_JOB_PRIORITY: 25

--- a/lava_test_plans/projects/lkft/devices/variables/juno-r2.yaml
+++ b/lava_test_plans/projects/lkft/devices/variables/juno-r2.yaml
@@ -1,7 +1,6 @@
 DEVICE_TYPE: juno-r2
 KERNEL_URL: unknown
 DTB_URL: unknown
-BOOT_URL: unknown
 MODULES_URL: unknown
 ROOTFS_URL: unknown
 LAVA_JOB_PRIORITY: 25

--- a/lava_test_plans/projects/lkft/devices/variables/rk3399-rock-pi-4b.yaml
+++ b/lava_test_plans/projects/lkft/devices/variables/rk3399-rock-pi-4b.yaml
@@ -1,7 +1,6 @@
 DEVICE_TYPE: rk3399-rock-pi-4b
 KERNEL_URL: unknown
 DTB_URL: unknown
-BOOT_URL: unknown
 MODULES_URL: unknown
 ROOTFS_URL: unknown
 LAVA_JOB_PRIORITY: 25

--- a/lava_test_plans/projects/lkft/devices/variables/x86.yaml
+++ b/lava_test_plans/projects/lkft/devices/variables/x86.yaml
@@ -1,6 +1,5 @@
 DEVICE_TYPE: x86
 KERNEL_URL: unknown
-BOOT_URL: unknown
 MODULES_URL: unknown
 ROOTFS_URL: unknown
 LAVA_JOB_PRIORITY: 25

--- a/lava_test_plans/testcases/ltp-short-run-2.yaml
+++ b/lava_test_plans/testcases/ltp-short-run-2.yaml
@@ -1,4 +1,4 @@
 {% extends "testcases/templates/ltp.yaml.jinja2" %}
 
-{% set testnames = ['fcntl-locktests', 'filecaps', 'fs_bind', 'fs_perms_simple', 'fsx'] %}
+{% set testnames = ['fcntl-locktests', 'filecaps', 'fs_bind', 'fs_perms_simple'] %}
 {% set test_timeout = 30 %}


### PR DESCRIPTION
The test cases in the fsx suite is moved into other suites in LTP release 20240129 and the fsx suite is removed.