### PR TITLE
projects: lkft: devices: varibles: e850: drop BOOT_URL

### DIFF
--- a/lava_test_plans/projects/lkft/devices/variables/e850-96.yaml
+++ b/lava_test_plans/projects/lkft/devices/variables/e850-96.yaml
@@ -1,7 +1,6 @@
 DEVICE_TYPE: e850-96
 KERNEL_URL: unknown
 DTB_URL: unknown
-BOOT_URL: unknown
 MODULES_URL: unknown
 ROOTFS_URL: unknown
 LAVA_JOB_PRIORITY: 25


### PR DESCRIPTION
BOOT_URL isn't needed for device e850-96.

Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>