### PR TITLE
projects: lkft: devices: rockpi4: update booti_dtb_addr

### DIFF
--- a/lava_test_plans/projects/lkft/devices/rk3399-rock-pi-4b
+++ b/lava_test_plans/projects/lkft/devices/rk3399-rock-pi-4b
@@ -15,5 +15,6 @@
 {% set EXTRA_KERNEL_ARGS = ' earlycon ' + EXTRA_KERNEL_ARGS|default("") %}
 {% block context %}
   {{ super() }}
+  booti_dtb_addr: "0x86000000"
   extra_nfsroot_args: ',vers=3'
 {% endblock context %}


### PR DESCRIPTION
The dtb_addr overwrite the kernel, due to that the kernel has grown to big and overlaps with the dtb.