### PR TITLE
testcases: kselftest-net-2: drop tc-testing

### DIFF
--- a/lava_test_plans/testcases/kselftest-net-2.yaml
+++ b/lava_test_plans/testcases/kselftest-net-2.yaml
@@ -1,4 +1,4 @@
 {% extends "testcases/templates/kselftest.yaml.jinja2" %}
 
-{% set testnames = ['netfilter', 'nsfs', 'tc-testing'] %}
+{% set testnames = ['netfilter', 'nsfs'] %}
 {% set test_timeout = 45 %}


### PR DESCRIPTION
Drop tc-testing from kselftest-net-2, tc-testing is already in kselftest-short-run-7.