### PR TITLE
master: add queue timeout

### DIFF
--- a/lava_test_plans/master.jinja2
+++ b/lava_test_plans/master.jinja2
@@ -34,6 +34,10 @@ timeouts:
   actions:
     finalize:
       seconds: 60
+{% if LAVA_QUEUE_TIMEOUT is defined %}
+  queue:
+    hours: {{ LAVA_QUEUE_TIMEOUT }}
+{% endif %}
 
 {% if use_context is defined and use_context == true %}
 context:


### PR DESCRIPTION
LAVA jobs can get stuck for weeks if the priority isn't set properly which makes it pointless running those jobs after a week/month when the artefacts isn't available anymore or when its to late (someone else already done it)to report a bug. Another aspect is that LAVA eat up a lot of time just parsing the queue to find the next job to schedule. By adding a LAVA queue timeout to the job so it gets canceled if not scheduled in time, makes the queue length manageable.