### PR TITLE
testcases: templates: kselftest: prefix timesync-off

### DIFF
--- a/lava_test_plans/testcases/templates/kselftest.yaml.jinja2
+++ b/lava_test_plans/testcases/templates/kselftest.yaml.jinja2
@@ -36,7 +36,7 @@
         run:
           steps:
           - systemctl stop systemd-timesyncd || true
-      name: timesync-off
+      name: kselftest-timesync-off
       path: inline/timesync-off.yaml
 {% for testname in testnames %}
     - repository: {{ TEST_DEFINITIONS_REPOSITORY }}


### PR DESCRIPTION
Prefix the test that stops systemd-timesyncd before kselftest suites are runned.

Reported-by: Benjamin Copeland <benjamin.copeland@linaro.org>