### PR TITLE
overlays: Implement overlays option

### DIFF
--- a/lava_test_plans/include/fastboot.jinja2
+++ b/lava_test_plans/include/fastboot.jinja2
@@ -168,6 +168,20 @@ reboot_to_fastboot: {{ reboot_to_fastboot }}
 {% if apply_overlay == "overlays" %}
         overlays:
 {% endif %}
+{% if overlays %}
+        overlays:
+{% endif %}
+{% for name, overlay, dst in overlays %}
+          {{ name }}:
+            url: "{{ overlay }}"
+            format: {{ compression(overlay)[0] }}
+{% if compression(overlay)[1] is not none %}
+            compression: {{ compression(overlay)[1] }}
+            path: "{{ dst }}"
+{% else %}
+            path: "{{ dst }}{{ overlay.split('/')[-1] }}"
+{% endif %}
+{% endfor %}
 {% if OVERLAY_URL is defined %}
           over:
             url: {{OVERLAY_URL}}

--- a/lava_test_plans/nfs.jinja2
+++ b/lava_test_plans/nfs.jinja2
@@ -96,6 +96,20 @@
 {% if apply_overlay == "overlays" %}
       overlays:
 {% endif %}
+{% if overlays %}
+      overlays:
+{% endif %}
+{% for name, overlay, dst in overlays %}
+        {{ name }}:
+          url: "{{ overlay }}"
+          format: {{ compression(overlay)[0] }}
+{% if compression(overlay)[1] is not none %}
+          compression: {{ compression(overlay)[1] }}
+          path: "{{ dst }}"
+{% else %}
+          path: "{{ dst }}{{ overlay.split('/')[-1] }}"
+{% endif %}
+{% endfor %}
 {% if OVERLAY_URL is defined %}
         over:
           url: {{OVERLAY_URL}}

--- a/lava_test_plans/qemu.jinja2
+++ b/lava_test_plans/qemu.jinja2
@@ -100,6 +100,20 @@
 {% block rootfs_extra_args %}
 {% endblock rootfs_extra_args %}
 {# Process the following block if any overlays provided #}
+{% if overlays %}
+        overlays:
+{% endif %}
+{% for name, overlay, dst in overlays %}
+          {{ name }}:
+            url: "{{ overlay }}"
+            format: {{ compression(overlay)[0] }}
+{% if compression(overlay)[1] is not none %}
+            compression: {{ compression(overlay)[1] }}
+            path: "{{ dst }}"
+{% else %}
+            path: "{{ dst }}{{ overlay.split('/')[-1] }}"
+{% endif %}
+{% endfor %}
 {% if OVERLAY_MODULES_URL is defined or
       OVERLAY_KSELFTEST_URL is defined or
       OVERLAY_PERF_URL is defined or


### PR DESCRIPTION
Usage:

```lava-test-plans --device-type x86 --variables ~/work/linaro/notes/lava-bridge/x86-variables-valid.yaml --testplan-device-path devices --dry-run --test-case boot.yaml --overlay https://storage.tuxboot.com/overlays/debian/trixie/amd64/ltp/20240524/ltp.tar.xz /tmp --overlay https://storage.tuxboot.com/overlays/debian/trixie/amd64/ltp/20240524/ltp-1.tar.xz /data --overlay https://storage.tuxboot.com/overlays/debian/trixie/amd64/ltp/20240524/ltp-2.tar.xz /var --overlay https://storage.tuxboot.com/overlays/debian/trixie/amd64/ltp/20240524/ltp-3.tar.xz```

The above should put overlays in the lava job definition at the right place.